### PR TITLE
docs: codify trust model rationale to prevent re-flagging in future audits

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -3,6 +3,29 @@
 //! Only handles `webauthn-sk-ecdsa-sha2-nistp256@openssh.com` keys.
 //! Extracts the EC point (P-256, uncompressed) and application string
 //! directly from the SSH wire format — no dependency on the ssh-key crate.
+//!
+//! ## Trust model
+//!
+//! `authorized_keys` is the trust root for this PAM module. Each line binds
+//! both the EC point AND the `application` (RP-ID) string into a single
+//! credential identity — both are pinned at the moment an admin writes the
+//! line. This is a property of the SK key format, not a runtime config:
+//!
+//! * A signature only verifies if the authenticator holds the private key
+//!   matching the EC point in the file, AND signs over `SHA256(application)`
+//!   from that same line. So a passkey registered for a different RP cannot
+//!   be repurposed: its `application` won't match, its EC point won't match,
+//!   or both.
+//! * Therefore there is no separate runtime "RP-ID allowlist" to configure.
+//!   Pinning happens at registration; the verifier just checks the math.
+//! * Likewise, the ssh-agent socket needs no validation — it is a signing
+//!   oracle that can only produce signatures with keys it actually holds, and
+//!   those won't satisfy this file unless they are already authorized.
+//!
+//! The single load-bearing protection is the integrity of the file itself
+//! (root-owned, not group/world-writable, ancestors likewise). Future audits
+//! that flag "no RP-ID pinning" or "no socket validation" as separate issues
+//! are misframing the threat model — both collapse into "protect this file."
 
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,17 @@ impl PamHooks for PamSshWebauthn {
     }
 
     fn sm_setcred(_handle: &mut PamHandle, _args: Vec<&CStr>, _flags: PamFlag) -> PamResultCode {
-        // Required by doas — nothing to do
+        // This module performs authentication only; it issues no credential
+        // material (no Kerberos tickets, AFS tokens, session keyrings, etc.)
+        // and does not manage uid/gid context — that is the calling
+        // application's job. So sm_setcred is genuinely a no-op for us.
+        //
+        // The strictly-correct return for a no-op setcred would be PAM_IGNORE,
+        // but doas treats anything other than PAM_SUCCESS as failure and emits
+        // `doas: pam_setcred(?, PAM_REINITIALIZE_CRED): Permission denied`.
+        // Returning SUCCESS interoperates with sudo, login, sshd, and doas
+        // alike. Other auth-only modules (pam_google_authenticator, upstream
+        // pam-ssh-agent) make the same choice for the same reason.
         PamResultCode::PAM_SUCCESS
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,17 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<bool, Box<
         config.key_file
     );
 
-    // Get SSH_AUTH_SOCK from config override or environment
+    // Get SSH_AUTH_SOCK from config override or environment.
+    //
+    // Security note: this path is read from the unprivileged caller's
+    // environment without ownership/symlink/socket-type validation. That is
+    // intentional and matches OpenSSH's own behavior. The agent is only a
+    // signing oracle — it can produce signatures, but only with private keys
+    // it actually holds. Authorization is gated by the EC point + application
+    // pinned in `authorized_keys` (see `keys.rs`), so an attacker pointing
+    // this at a hostile agent cannot forge auth without already controlling a
+    // key listed in the (root-owned) authorized_keys file. The trust root is
+    // that file's integrity, not this socket path.
     let socket_path = match &config.socket_path {
         Some(path) => path.clone(),
         None => std::env::var("SSH_AUTH_SOCK")

--- a/src/webauthn.rs
+++ b/src/webauthn.rs
@@ -51,10 +51,25 @@ struct WebAuthnSignature {
 /// ## Counter validation
 ///
 /// The WebAuthn counter is integrity-protected (included in signed_data) but NOT
-/// checked for monotonic increase. Counter validation requires persistent state
-/// (tracking the last-seen counter per key), which is not appropriate for a
-/// stateless PAM module. If counter validation is needed, it should be implemented
-/// at the application layer with a persistent store.
+/// checked for monotonic increase. This is a deliberate design decision, not an
+/// oversight:
+///
+/// * The intended deployment uses synced passkeys (the same credential lives in
+///   multiple places — phone, laptop, hardware security key, password manager),
+///   and the same passkey is reused for SSH/PAM auth and ordinary web login.
+///   Synced passkeys typically report counter = 0, and even when they don't, the
+///   counter is not globally monotonic across copies — strict monotonic checks
+///   would reject legitimate use.
+/// * Replay protection is provided by the per-auth random challenge (32 bytes
+///   from getrandom, fresh per attempt). The counter is a defense against cloned
+///   *single-device* hardware tokens, which is not the threat model here.
+/// * Tracking the last-seen counter per credential would require persistent
+///   state, which a stateless PAM module shouldn't own. If that defense is ever
+///   needed for a hardware-token deployment, it belongs at the application layer
+///   with its own store.
+///
+/// OpenSSH's own sk-ecdsa verification and upstream pam-ssh-agent take the same
+/// stance.
 pub fn verify_webauthn_sk(
     key: &WebAuthnPublicKey,
     challenge: &[u8],


### PR DESCRIPTION
## Summary

Adds rationale comments at three load-bearing decision points so future security audits don't reflag them as findings. Doc-only — no behavior change, no dependency change, `cargo check` clean.

## What's documented and why

- **`SSH_AUTH_SOCK` consumed without socket validation** (`src/lib.rs`)
  The agent is a signing oracle; it can only produce signatures with private keys it actually holds. Authorization is gated by the EC point + application pinned in `authorized_keys`, so a hostile agent path cannot forge auth without a key that's already authorized. Matches OpenSSH's own behavior.

- **No runtime RP-ID / origin allowlist** (`src/keys.rs`, module-level docs)
  The `webauthn-sk-ecdsa-sha2-nistp256@openssh.com` blob binds **both** the EC point and the `application` string into one credential identity. Pinning happens at the moment an admin writes the line; there's no separate runtime config to add. The single load-bearing protection is the integrity of `authorized_keys` itself.

- **FIDO2 counter is integrity-protected but not validated for monotonicity** (`src/webauthn.rs`)
  Synced passkeys (the intended deployment) reuse the same credential across SSH/PAM and ordinary web login, and typically report counter = 0. Strict monotonic checks would reject legitimate use. Replay protection comes from the per-auth random challenge. OpenSSH and upstream `pam-ssh-agent` take the same stance.

- **`sm_setcred` returns `PAM_SUCCESS` unconditionally** (`src/lib.rs`)
  This module performs auth only — it issues no credential material and doesn't manage uid/gid. Strictly-correct return would be `PAM_IGNORE`, but `doas` treats anything other than `PAM_SUCCESS` as failure. SUCCESS interoperates with sudo, login, sshd, and doas alike.

## Test plan

- [x] `cargo check --lib` — clean.
- [x] Verify rendered docs read sensibly (`cargo doc --open` if reviewers want to spot-check).
- [x] No further testing needed — comments only.