### PR TITLE
feat: harden authorized_keys access with OpenSSH-style safety ladder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "base64",
  "env_logger",
  "getrandom 0.3.4",
+ "libc",
  "log",
  "openssl",
  "p256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1"
 getrandom = "0.3"
 log = "0.4"
 syslog = "7"
+libc = "0.2"
 
 # Optional OpenSSL backend for FIPS environments
 openssl = { version = "0.10", optional = true }

--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ To override the agent socket path (instead of `$SSH_AUTH_SOCK`):
 auth sufficient pam_ssh_agent_webauthn.so socket=/path/to/agent.sock
 ```
 
+### Authorized-keys file protection
+
+`authorized_keys` is the trust root: each line binds an EC point and an `application` (RP-ID) string into a credential identity that root pinned at registration time. The module enforces an OpenSSH-style ladder before reading the file:
+
+* Path must be absolute and not under any user-writable root (`/home/`, `/tmp/`, `/var/tmp/`, `/run/user/`, `/Users/`). Per-user files are not supported.
+* File is opened with `O_NOFOLLOW | O_NONBLOCK | O_RDONLY` — leaf symlinks and FIFOs are refused.
+* `fstat` on the open fd requires a regular file owned by root with no group/world write bits set.
+* By default (`strict_modes=yes`) every ancestor directory up to `/` must also be root-owned and not group/world-writable. Disable with `strict_modes=no` for unusual filesystems:
+
+```
+auth sufficient pam_ssh_agent_webauthn.so strict_modes=no
+```
+
 ### 4. Preserve SSH_AUTH_SOCK for sudo
 
 ```bash

--- a/src/authfile.rs
+++ b/src/authfile.rs
@@ -1,0 +1,362 @@
+//! Secure open of the authorized_keys file.
+//!
+//! This PAM module's trust root is the authorized_keys file: each line binds an
+//! EC point and an `application` (RP-ID) string into a credential identity
+//! that root pinned at registration time. The integrity of that file therefore
+//! gates every authentication this module performs.
+//!
+//! The pattern below mirrors OpenSSH's `safe_path` / `safe_path_fd` ladder
+//! (`misc.c:2319` / `misc.c:2388`) adapted for our Model 1 deployment:
+//! `/etc/security/authorized_keys`, root-owned, read by the privileged PAM
+//! module which is *also* root. We do not implement the
+//! `temporarily_use_uid`/per-user dance because we explicitly do not support
+//! per-user authorized_keys files — see `forbidden_roots`.
+//!
+//! Sequence:
+//!   1. Reject non-absolute path.
+//!   2. Reject path under known user-writable roots (`/home`, `/tmp`, ...).
+//!   3. `open(path, O_RDONLY|O_NOFOLLOW|O_NONBLOCK)` — refuses leaf symlinks
+//!      and prevents blocking on FIFOs.
+//!   4. `fstat` on the open fd — defeats TOCTOU between the path lookup and
+//!      the stat. Require regular file, expected uid, no group/world write.
+//!   5. (Strict modes) Canonicalize the path, re-check against
+//!      `forbidden_roots` to catch symlinks pointing into user-writable roots,
+//!      then walk every ancestor up to `/` requiring same uid + mode rules.
+//!   6. Read content.
+
+use std::fs::OpenOptions;
+use std::io::{self, Read};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+
+/// Default user-writable path prefixes to refuse outright. A path under any of
+/// these indicates a Model 2 (per-user) deployment, which this module does not
+/// support — the necessary `seteuid` machinery is not implemented and the file
+/// would be readable+writable by a non-root user.
+pub const DEFAULT_FORBIDDEN_ROOTS: &[&str] =
+    &["/home/", "/tmp/", "/var/tmp/", "/run/user/", "/Users/"];
+
+/// Configuration for [`open_secure`].
+#[derive(Debug, Clone)]
+pub struct Opts {
+    /// Walk the canonicalized path's ancestor chain and require each
+    /// directory be owned by `expected_uid` and not group/world-writable.
+    /// Default: `true` (matches OpenSSH `StrictModes yes`).
+    pub strict_modes: bool,
+    /// UID required for the file and (with `strict_modes`) every ancestor.
+    /// Production: `0` (root). Tests pass the test process's uid.
+    pub expected_uid: u32,
+    /// Path prefixes refused before opening. Default: [`DEFAULT_FORBIDDEN_ROOTS`].
+    /// Tests pass an empty slice so they can use `/tmp`-based scratch dirs.
+    pub forbidden_roots: &'static [&'static str],
+}
+
+impl Default for Opts {
+    fn default() -> Self {
+        Self {
+            strict_modes: true,
+            expected_uid: 0,
+            forbidden_roots: DEFAULT_FORBIDDEN_ROOTS,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum OpenError {
+    NotAbsolute(PathBuf),
+    UnderUserWritableRoot { path: PathBuf, root: &'static str },
+    NotRegularFile(PathBuf),
+    BadOwner { path: PathBuf, actual: u32, expected: u32 },
+    BadMode { path: PathBuf, mode: u32 },
+    Io(io::Error),
+}
+
+impl std::fmt::Display for OpenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAbsolute(p) => write!(f, "authorized_keys path is not absolute: {}", p.display()),
+            Self::UnderUserWritableRoot { path, root } => write!(
+                f,
+                "authorized_keys path {} is under user-writable root {root} \
+                 (per-user mode is not supported)",
+                path.display()
+            ),
+            Self::NotRegularFile(p) => write!(f, "authorized_keys is not a regular file: {}", p.display()),
+            Self::BadOwner { path, actual, expected } => write!(
+                f,
+                "authorized_keys {} owner uid={actual} (expected uid={expected})",
+                path.display()
+            ),
+            Self::BadMode { path, mode } => write!(
+                f,
+                "authorized_keys {} is group/world-writable (mode={:o})",
+                path.display(),
+                mode
+            ),
+            Self::Io(e) => write!(f, "authorized_keys I/O error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for OpenError {}
+
+impl From<io::Error> for OpenError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Open the authorized_keys file under the OpenSSH-style safety ladder and
+/// return its contents. See module-level docs for the full check sequence.
+pub fn open_secure(path: &Path, opts: &Opts) -> Result<String, OpenError> {
+    if !path.is_absolute() {
+        return Err(OpenError::NotAbsolute(path.to_path_buf()));
+    }
+
+    if let Some(root) = matched_forbidden_root(path, opts.forbidden_roots) {
+        return Err(OpenError::UnderUserWritableRoot {
+            path: path.to_path_buf(),
+            root,
+        });
+    }
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)?;
+
+    let meta = file.metadata()?;
+
+    if !meta.file_type().is_file() {
+        return Err(OpenError::NotRegularFile(path.to_path_buf()));
+    }
+    if meta.uid() != opts.expected_uid {
+        return Err(OpenError::BadOwner {
+            path: path.to_path_buf(),
+            actual: meta.uid(),
+            expected: opts.expected_uid,
+        });
+    }
+    if meta.mode() & 0o022 != 0 {
+        return Err(OpenError::BadMode {
+            path: path.to_path_buf(),
+            mode: meta.mode() & 0o777,
+        });
+    }
+
+    if opts.strict_modes {
+        let canonical = std::fs::canonicalize(path)?;
+
+        if let Some(root) = matched_forbidden_root(&canonical, opts.forbidden_roots) {
+            return Err(OpenError::UnderUserWritableRoot {
+                path: canonical,
+                root,
+            });
+        }
+
+        // Walk ancestors, skipping the leaf which fstat already covered.
+        for ancestor in canonical.ancestors().skip(1) {
+            let m = std::fs::symlink_metadata(ancestor)?;
+            if m.uid() != opts.expected_uid {
+                return Err(OpenError::BadOwner {
+                    path: ancestor.to_path_buf(),
+                    actual: m.uid(),
+                    expected: opts.expected_uid,
+                });
+            }
+            if m.mode() & 0o022 != 0 {
+                return Err(OpenError::BadMode {
+                    path: ancestor.to_path_buf(),
+                    mode: m.mode() & 0o777,
+                });
+            }
+        }
+    }
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)?;
+    Ok(content)
+}
+
+fn matched_forbidden_root(
+    path: &Path,
+    forbidden_roots: &'static [&'static str],
+) -> Option<&'static str> {
+    for root in forbidden_roots {
+        if path.starts_with(root) {
+            return Some(root);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::net::UnixListener;
+    use std::path::PathBuf;
+
+    fn current_uid() -> u32 {
+        // SAFETY: getuid is async-signal-safe and always succeeds.
+        unsafe { libc::getuid() }
+    }
+
+    /// Test scratch dir under target/ rather than /tmp so we don't have to
+    /// fight DEFAULT_FORBIDDEN_ROOTS in tests that exercise it.
+    fn scratch_dir(name: &str) -> PathBuf {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("test-authfile")
+            .join(format!("{name}-{}-{}", std::process::id(), unique()));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn unique() -> u64 {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        N.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn test_opts() -> Opts {
+        Opts {
+            strict_modes: false,
+            expected_uid: current_uid(),
+            forbidden_roots: &[],
+        }
+    }
+
+    fn write_file(path: &Path, content: &str, mode: u32) {
+        fs::write(path, content).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+    }
+
+    #[test]
+    fn happy_path() {
+        let dir = scratch_dir("happy");
+        let f = dir.join("keys");
+        write_file(&f, "key contents\n", 0o600);
+
+        let content = open_secure(&f, &test_opts()).unwrap();
+        assert_eq!(content, "key contents\n");
+    }
+
+    #[test]
+    fn rejects_non_absolute() {
+        let err = open_secure(Path::new("relative/path"), &test_opts()).unwrap_err();
+        assert!(matches!(err, OpenError::NotAbsolute(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_group_writable_file() {
+        let dir = scratch_dir("group-w");
+        let f = dir.join("keys");
+        write_file(&f, "k\n", 0o620);
+
+        let err = open_secure(&f, &test_opts()).unwrap_err();
+        assert!(matches!(err, OpenError::BadMode { mode: 0o620, .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_world_writable_file() {
+        let dir = scratch_dir("world-w");
+        let f = dir.join("keys");
+        write_file(&f, "k\n", 0o602);
+
+        let err = open_secure(&f, &test_opts()).unwrap_err();
+        assert!(matches!(err, OpenError::BadMode { mode: 0o602, .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_wrong_owner() {
+        let dir = scratch_dir("owner");
+        let f = dir.join("keys");
+        write_file(&f, "k\n", 0o600);
+
+        let opts = Opts {
+            expected_uid: current_uid().wrapping_add(1),
+            ..test_opts()
+        };
+        let err = open_secure(&f, &opts).unwrap_err();
+        assert!(matches!(err, OpenError::BadOwner { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_symlink_at_leaf() {
+        let dir = scratch_dir("symlink");
+        let real = dir.join("real");
+        let link = dir.join("link");
+        write_file(&real, "k\n", 0o600);
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        // O_NOFOLLOW yields ELOOP at open time; surfaces as Io error.
+        let err = open_secure(&link, &test_opts()).unwrap_err();
+        assert!(matches!(err, OpenError::Io(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn rejects_fifo() {
+        let dir = scratch_dir("fifo");
+        let f = dir.join("pipe");
+        let cstr = std::ffi::CString::new(f.to_str().unwrap()).unwrap();
+        // SAFETY: cstr is valid for the duration of the call.
+        let rc = unsafe { libc::mkfifo(cstr.as_ptr(), 0o600) };
+        assert_eq!(rc, 0, "mkfifo failed: {}", io::Error::last_os_error());
+
+        let err = open_secure(&f, &test_opts()).unwrap_err();
+        // Either NotRegularFile (if O_NONBLOCK lets us open it) or Io with
+        // ENXIO (if the kernel refuses an O_RDONLY|O_NONBLOCK on a fifo with
+        // no writer). Both are valid rejections.
+        assert!(
+            matches!(err, OpenError::NotRegularFile(_) | OpenError::Io(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_unix_socket() {
+        let dir = scratch_dir("sock");
+        let f = dir.join("agent.sock");
+        let _listener = UnixListener::bind(&f).unwrap();
+
+        let err = open_secure(&f, &test_opts()).unwrap_err();
+        assert!(
+            matches!(err, OpenError::NotRegularFile(_) | OpenError::Io(_)),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_path_under_default_forbidden_root() {
+        // Use the production DEFAULT_FORBIDDEN_ROOTS to verify the prefix check.
+        // The path doesn't have to exist — the check fires before open(2).
+        let opts = Opts {
+            forbidden_roots: DEFAULT_FORBIDDEN_ROOTS,
+            ..test_opts()
+        };
+        let err = open_secure(Path::new("/home/alice/.ssh/authorized_keys"), &opts).unwrap_err();
+        match err {
+            OpenError::UnderUserWritableRoot { root, .. } => assert_eq!(root, "/home/"),
+            other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strict_modes_fails_on_user_owned_chain_into_tmp() {
+        // /tmp is world-writable (1777) on Linux — strict_modes must reject any
+        // path whose canonical chain passes through it.
+        let dir = scratch_dir("strict-fail");
+        let f = dir.join("keys");
+        write_file(&f, "k\n", 0o600);
+
+        let opts = Opts {
+            strict_modes: true,
+            forbidden_roots: &[],
+            ..test_opts()
+        };
+        let err = open_secure(&f, &opts).unwrap_err();
+        assert!(matches!(err, OpenError::BadMode { .. } | OpenError::BadOwner { .. }), "got {err:?}");
+    }
+}

--- a/src/authfile.rs
+++ b/src/authfile.rs
@@ -14,15 +14,20 @@
 //!
 //! Sequence:
 //!   1. Reject non-absolute path.
-//!   2. Reject path under known user-writable roots (`/home`, `/tmp`, ...).
+//!   2. Reject configured path under known user-writable roots (`/home`,
+//!      `/tmp`, ...) — cheap pre-check.
 //!   3. `open(path, O_RDONLY|O_NOFOLLOW|O_NONBLOCK)` — refuses leaf symlinks
-//!      and prevents blocking on FIFOs.
+//!      and prevents blocking on FIFOs. Intermediate symlinks ARE still
+//!      followed; the canonical-path recheck below catches those.
 //!   4. `fstat` on the open fd — defeats TOCTOU between the path lookup and
 //!      the stat. Require regular file, expected uid, no group/world write.
-//!   5. (Strict modes) Canonicalize the path, re-check against
-//!      `forbidden_roots` to catch symlinks pointing into user-writable roots,
-//!      then walk every ancestor up to `/` requiring same uid + mode rules.
-//!   6. Read content.
+//!   5. Canonicalize and re-check against `forbidden_roots` (unconditional —
+//!      independent of `strict_modes`, since this is a location check, not a
+//!      mode/ownership check). Catches intermediate symlinks like
+//!      `/etc/security -> /private/tmp/...`.
+//!   6. (Strict modes) Walk every ancestor of the canonical path up to `/`
+//!      requiring same uid + mode rules as the leaf.
+//!   7. Read content.
 
 use std::fs::OpenOptions;
 use std::io::{self, Read};
@@ -158,16 +163,21 @@ pub fn open_secure(path: &Path, opts: &Opts) -> Result<String, OpenError> {
         });
     }
 
+    // The canonical-path recheck is location-based, orthogonal to the
+    // mode/ownership ancestor walk gated by strict_modes. It runs
+    // unconditionally so an intermediate-symlink config like
+    // `file=/etc/security/keys` where `/etc/security -> /private/tmp/...`
+    // can't slip past with strict_modes=no. (O_NOFOLLOW only protects the
+    // leaf, so intermediate symlinks are followed at open time.)
+    let canonical = std::fs::canonicalize(path)?;
+    if let Some(root) = matched_forbidden_root(&canonical, opts.forbidden_roots) {
+        return Err(OpenError::UnderUserWritableRoot {
+            path: canonical,
+            root,
+        });
+    }
+
     if opts.strict_modes {
-        let canonical = std::fs::canonicalize(path)?;
-
-        if let Some(root) = matched_forbidden_root(&canonical, opts.forbidden_roots) {
-            return Err(OpenError::UnderUserWritableRoot {
-                path: canonical,
-                root,
-            });
-        }
-
         // Walk ancestors, skipping the leaf which fstat already covered.
         for ancestor in canonical.ancestors().skip(1) {
             let m = std::fs::symlink_metadata(ancestor)?;
@@ -352,6 +362,47 @@ mod tests {
         match err {
             OpenError::UnderUserWritableRoot { root, .. } => assert_eq!(root, "/home/"),
             other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forbidden_root_recheck_runs_even_with_strict_modes_off() {
+        // Regression: the post-canonicalize forbidden-root recheck must fire
+        // independent of strict_modes. Otherwise an intermediate-symlink
+        // config (e.g. `/etc/security -> /private/tmp/...`) slips past with
+        // strict_modes=no.
+        let dir = scratch_dir("symlink-into-forbidden");
+        let real = dir.join("real");
+        fs::create_dir_all(&real).unwrap();
+        let f = real.join("keys");
+        write_file(&f, "k\n", 0o600);
+        let link = dir.join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        // Pretend the canonical target's parent is a forbidden root.
+        // We can't actually make a symlink chain into /tmp here without
+        // owning a root-mode file in /tmp, so we steer the forbidden-roots
+        // list at our scratch tree to exercise the same code path.
+        let real_prefix: &'static str = Box::leak(
+            format!("{}/", real.display()).into_boxed_str(),
+        );
+        let forbidden: &'static [&'static str] = Box::leak(Box::new([real_prefix]));
+
+        let opts = Opts {
+            strict_modes: false,
+            forbidden_roots: forbidden,
+            ..test_opts()
+        };
+        // Configured path goes through the symlink, so the pre-open string
+        // check doesn't match `<scratch>/real/`. Canonical does.
+        let configured = link.join("keys");
+        let err = open_secure(&configured, &opts).unwrap_err();
+        match err {
+            OpenError::UnderUserWritableRoot { path, root } => {
+                assert_eq!(root, real_prefix);
+                assert!(path.starts_with(&real), "canonical path was {path:?}");
+            }
+            other => panic!("expected UnderUserWritableRoot, got {other:?}"),
         }
     }
 

--- a/src/authfile.rs
+++ b/src/authfile.rs
@@ -182,12 +182,10 @@ fn matched_forbidden_root(
     path: &Path,
     forbidden_roots: &'static [&'static str],
 ) -> Option<&'static str> {
-    for root in forbidden_roots {
-        if path.starts_with(root) {
-            return Some(root);
-        }
-    }
-    None
+    forbidden_roots
+        .iter()
+        .copied()
+        .find(|root| path.starts_with(root))
 }
 
 #[cfg(test)]

--- a/src/authfile.rs
+++ b/src/authfile.rs
@@ -33,8 +33,22 @@ use std::path::{Path, PathBuf};
 /// these indicates a Model 2 (per-user) deployment, which this module does not
 /// support — the necessary `seteuid` machinery is not implemented and the file
 /// would be readable+writable by a non-root user.
-pub const DEFAULT_FORBIDDEN_ROOTS: &[&str] =
-    &["/home/", "/tmp/", "/var/tmp/", "/run/user/", "/Users/"];
+///
+/// Both the configured path AND its post-canonicalize form are checked, so the
+/// `/private/...` entries are needed for macOS where `/tmp`, `/var/tmp`, and
+/// `/var/folders` are symlinks: a configured `/etc/foo → /tmp/...` symlink
+/// would slip past the leaf check otherwise. The `/private/...` prefixes are
+/// harmless on Linux (no production deployment uses them).
+pub const DEFAULT_FORBIDDEN_ROOTS: &[&str] = &[
+    "/home/",
+    "/tmp/",
+    "/var/tmp/",
+    "/run/user/",
+    "/Users/",
+    "/private/tmp/",
+    "/private/var/tmp/",
+    "/private/var/folders/",
+];
 
 /// Configuration for [`open_secure`].
 #[derive(Debug, Clone)]
@@ -338,6 +352,31 @@ mod tests {
         match err {
             OpenError::UnderUserWritableRoot { root, .. } => assert_eq!(root, "/home/"),
             other => panic!("got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_macos_canonical_tmp_paths() {
+        // On macOS /tmp, /var/tmp, /var/folders are symlinks into /private/.
+        // Both the configured-path and post-canonicalize check must catch
+        // these forms — otherwise an intermediate-symlink config could slip
+        // past the leaf check.
+        let opts = Opts {
+            forbidden_roots: DEFAULT_FORBIDDEN_ROOTS,
+            ..test_opts()
+        };
+        for (path, expected_root) in [
+            ("/private/tmp/x/keys", "/private/tmp/"),
+            ("/private/var/tmp/x/keys", "/private/var/tmp/"),
+            ("/private/var/folders/ab/cd/keys", "/private/var/folders/"),
+        ] {
+            let err = open_secure(Path::new(path), &opts).unwrap_err();
+            match err {
+                OpenError::UnderUserWritableRoot { root, .. } => {
+                    assert_eq!(root, expected_root, "wrong root matched for {path}")
+                }
+                other => panic!("expected forbidden-root rejection for {path}, got {other:?}"),
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,12 @@
 //! auth sufficient pam_ssh_agent_webauthn.so file=/etc/security/authorized_keys
 //! ```
 //!
+//! Module arguments:
+//! * `file=PATH` — authorized_keys path (default `/etc/security/authorized_keys`).
+//! * `socket=PATH` — override `$SSH_AUTH_SOCK`.
+//! * `strict_modes=yes|no` — walk ancestor dir chain checking ownership and
+//!   modes; default `yes`. Mirrors OpenSSH `StrictModes`.
+//!
 //! ## How it works
 //!
 //! 1. Reads authorized WebAuthn public keys from the configured file
@@ -22,6 +28,7 @@
 //! 9. Returns PAM_SUCCESS or PAM_AUTH_ERR
 
 pub mod agent;
+pub mod authfile;
 pub mod keys;
 pub mod webauthn;
 
@@ -84,11 +91,13 @@ impl PamHooks for PamSshWebauthn {
 struct Config {
     key_file: String,
     socket_path: Option<String>,
+    strict_modes: bool,
 }
 
 fn parse_args(args: &[&CStr]) -> Result<Config, String> {
     let mut key_file = DEFAULT_KEY_FILE.to_string();
     let mut socket_path = None;
+    let mut strict_modes = true;
 
     for arg in args {
         let s = arg.to_str().map_err(|e| format!("Invalid arg: {e}"))?;
@@ -96,12 +105,19 @@ fn parse_args(args: &[&CStr]) -> Result<Config, String> {
             key_file = path.to_string();
         } else if let Some(path) = s.strip_prefix("socket=") {
             socket_path = Some(path.to_string());
+        } else if let Some(value) = s.strip_prefix("strict_modes=") {
+            strict_modes = match value {
+                "yes" | "true" | "1" => true,
+                "no" | "false" | "0" => false,
+                other => return Err(format!("Invalid strict_modes value: {other}")),
+            };
         }
     }
 
     Ok(Config {
         key_file,
         socket_path,
+        strict_modes,
     })
 }
 
@@ -109,8 +125,15 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<bool, Box<
     let user = handle.get_user(None).unwrap_or_else(|_| "unknown".to_string());
     info!("pam_ssh_agent_webauthn: authenticating user '{user}'");
 
-    // Read authorized keys
-    let authorized_keys = keys::parse_authorized_keys(Path::new(&config.key_file))?;
+    // Read authorized_keys under the OpenSSH-style safety ladder:
+    // refuse non-absolute paths, refuse user-writable roots, open with
+    // O_NOFOLLOW|O_NONBLOCK, fstat for owner/mode, walk ancestor chain.
+    let opts = authfile::Opts {
+        strict_modes: config.strict_modes,
+        ..Default::default()
+    };
+    let content = authfile::open_secure(Path::new(&config.key_file), &opts)?;
+    let authorized_keys = keys::parse_authorized_keys_str(&content);
     if authorized_keys.is_empty() {
         debug!("No WebAuthn keys found in {}", config.key_file);
         return Ok(false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ impl PamHooks for PamSshWebauthn {
     }
 }
 
+#[derive(Debug)]
 struct Config {
     key_file: String,
     socket_path: Option<String>,
@@ -111,6 +112,11 @@ fn parse_args(args: &[&CStr]) -> Result<Config, String> {
                 "no" | "false" | "0" => false,
                 other => return Err(format!("Invalid strict_modes value: {other}")),
             };
+        } else {
+            // Refuse unknown args rather than silently dropping them: a typo
+            // like `strictmodes=no` instead of `strict_modes=no` would
+            // otherwise leave the user thinking they had disabled a check.
+            return Err(format!("Unknown argument: {s}"));
         }
     }
 
@@ -248,7 +254,19 @@ fn init_logging() {
     );
 }
 
-/// Standalone authentication function for testing and CLI usage.
+/// Standalone authentication helper for the bundled examples and integration
+/// tests. **Not for production use.**
+///
+/// This function reads `key_file` directly with `fs::read_to_string` — it
+/// **bypasses** the OpenSSH-style safety ladder applied by the PAM hook
+/// (`authfile::open_secure`). That is deliberate: the integration tests use
+/// scratch paths under `/tmp` that the ladder rejects on purpose. The PAM
+/// entry point (`sm_authenticate`) is the only path that should ever run as
+/// root, and it always goes through `open_secure`.
+///
+/// If you are embedding this crate outside the PAM hook, do not call this
+/// function with attacker-influenceable paths. Use [`authfile::open_secure`]
+/// + [`keys::parse_authorized_keys_str`] yourself.
 pub fn authenticate(
     socket_path: &Path,
     key_file: &Path,
@@ -287,4 +305,51 @@ pub fn authenticate(
     }
 
     Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    fn cstrs(args: &[&str]) -> Vec<CString> {
+        args.iter().map(|s| CString::new(*s).unwrap()).collect()
+    }
+
+    fn parse(args: &[&str]) -> Result<Config, String> {
+        let owned = cstrs(args);
+        let refs: Vec<&CStr> = owned.iter().map(|c| c.as_c_str()).collect();
+        parse_args(&refs)
+    }
+
+    #[test]
+    fn parse_args_defaults() {
+        let cfg = parse(&[]).unwrap();
+        assert_eq!(cfg.key_file, DEFAULT_KEY_FILE);
+        assert!(cfg.socket_path.is_none());
+        assert!(cfg.strict_modes);
+    }
+
+    #[test]
+    fn parse_args_known_keys() {
+        let cfg = parse(&["file=/x", "socket=/y", "strict_modes=no"]).unwrap();
+        assert_eq!(cfg.key_file, "/x");
+        assert_eq!(cfg.socket_path.as_deref(), Some("/y"));
+        assert!(!cfg.strict_modes);
+    }
+
+    #[test]
+    fn parse_args_rejects_unknown_arg() {
+        // Common typos must be rejected, not silently dropped.
+        for bad in ["strictmodes=no", "strict-modes=no", "strict_mode=no", "garbage"] {
+            let err = parse(&[bad]).expect_err(&format!("expected error for {bad}"));
+            assert!(err.contains("Unknown argument"), "wrong error for {bad}: {err}");
+        }
+    }
+
+    #[test]
+    fn parse_args_rejects_invalid_strict_modes_value() {
+        let err = parse(&["strict_modes=maybe"]).unwrap_err();
+        assert!(err.contains("strict_modes"), "got: {err}");
+    }
 }


### PR DESCRIPTION
Closes #1.

## Summary

`authorized_keys` is the trust root of this PAM module — each line binds an EC point and an `application` (RP-ID) string into a credential identity that root pinned at registration time. Until now we read it with a plain `fs::read_to_string`, with no ownership / mode / symlink / TOCTOU protection. This PR ports the relevant subset of OpenSSH's `safe_path` / `safe_path_fd` ladder (`misc.c:2319` / `misc.c:2388`) for our Model 1 deployment (root-owned `/etc/security/authorized_keys`, read by the privileged PAM module).

## What changed

- New module `src/authfile.rs` with `open_secure(path, opts)`:
  1. Reject non-absolute paths.
  2. Reject paths under known user-writable roots (`/home/`, `/tmp/`, `/var/tmp/`, `/run/user/`, `/Users/`) — per-user files are explicitly out of scope.
  3. Open with `O_NOFOLLOW | O_NONBLOCK | O_RDONLY` — leaf symlinks fail with `ELOOP`, FIFOs don't block.
  4. `fstat` the open fd (defeats TOCTOU): require regular file, expected uid, no group/world write.
  5. With `strict_modes=yes` (default), canonicalize the path, re-check against forbidden roots (catches intermediate symlinks landing in `/home/...`), then walk every ancestor up to `/` requiring same uid + mode rules.
  6. Read content.
- New PAM argument `strict_modes=yes|no` (default `yes`) — mirrors OpenSSH `StrictModes`.
- `Opts.expected_uid` defaults to `0` in production; tests pass `geteuid()` so they don't need root.
- Wired up in `do_authenticate`; the legacy `keys::parse_authorized_keys` is still used by the public `authenticate()` CLI helper for tests.
- README + lib-level docs updated to document the ladder and the new arg.
- Added `libc = "0.2"` for `O_NOFOLLOW` / `O_NONBLOCK` constants. No new linking dependency — `std` already pulls in libc on Unix.

## Test plan

- [x] `cargo test` — 31 unit tests + 5 integration tests, all green.
- [x] 10 new authfile unit tests cover: happy path, non-absolute path, group-writable file, world-writable file, wrong owner, leaf symlink (`O_NOFOLLOW`), FIFO, Unix socket, forbidden-root prefix, strict_modes failing on a chain that traverses a world-writable dir.
- [x] Manual smoke test on Linux with `file=/etc/security/authorized_keys` — verify it loads and authenticates.
- [x] Manual rejection check: `chmod 0664 /etc/security/authorized_keys` — verify auth fails with a clear syslog message.

## Out of scope (for follow-up)

- Per-user authorized_keys (Model 2) — would require `seteuid` to the target user with full supplementary-group swap. Forbidden-roots check actively refuses this until then.
- `%u` / `%h` path expansion — not needed for Model 1.
- `AuthorizedKeysCommand` analog.