### PR TITLE
feat(pam): distinguish service errors from auth failures in PAM return codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ auth sufficient pam_ssh_agent_webauthn.so socket=/path/to/agent.sock
 auth sufficient pam_ssh_agent_webauthn.so strict_modes=no
 ```
 
+### PAM return codes
+
+The module distinguishes failure modes so PAM stacks can route on them:
+
+| Return code | Condition |
+|---|---|
+| `PAM_SUCCESS` | A matching key signed the challenge and the signature verified. |
+| `PAM_AUTH_ERR` | No agent key matched `authorized_keys`, or every matched key was refused / failed verification (user denied the touch, agent rejected, etc.). |
+| `PAM_AUTHINFO_UNAVAIL` | `SSH_AUTH_SOCK` not set, agent socket unreachable, agent advertises no WebAuthn keys, or `authorized_keys` is empty. The module is fine — the info needed to authenticate just isn't present. |
+| `PAM_SERVICE_ERR` | Module misconfiguration (bad arg, unreadable / unsafe `authorized_keys`), or the agent returned a malformed protocol message. |
+| `PAM_USER_UNKNOWN` | PAM did not supply a user identity. |
+
+This lets you compose stacks like:
+
+```
+auth [success=ok auth_err=die authinfo_unavail=ignore default=die] \
+     pam_ssh_agent_webauthn.so
+auth requisite pam_unix.so
+```
+
+— "if WebAuthn auth succeeded, accept; if the user actively failed, deny; if the user has no agent forwarded, fall through to passwords."
+
 ### 4. Preserve SSH_AUTH_SOCK for sudo
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ The module distinguishes failure modes so PAM stacks can route on them:
 This lets you compose stacks like:
 
 ```
-auth [success=ok auth_err=die authinfo_unavail=ignore default=die] \
+auth [success=done auth_err=die authinfo_unavail=ignore default=ignore] \
      pam_ssh_agent_webauthn.so
 auth requisite pam_unix.so
 ```
 
-— "if WebAuthn auth succeeded, accept; if the user actively failed, deny; if the user has no agent forwarded, fall through to passwords."
+— "if WebAuthn auth succeeded, accept and stop (`success=done`); if the user actively failed, deny; if the user has no agent forwarded or no keys configured, fall through to passwords."
 
 ### 4. Preserve SSH_AUTH_SOCK for sudo
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,15 @@ impl PamHooks for PamSshWebauthn {
             }
             Err(e) => {
                 let code = e.pam_code();
-                // Service errors get error!; everything else is info!. The
-                // distinction matters because admins triaging a syslog stream
-                // should see broken-config / malformed-protocol issues
-                // separately from "user denied the touch."
-                if matches!(e, AuthError::Service(_)) {
+                // Service errors and UserUnknown get error!; everything else
+                // is info!. The distinction matters because admins triaging
+                // a syslog stream should see broken-config / malformed-
+                // protocol issues — and a calling app that failed to set
+                // PAM_USER before pam_authenticate (UserUnknown) is the same
+                // class of "module was called wrong" — separately from the
+                // expected "user denied the touch" / "no agent forwarded"
+                // events.
+                if matches!(e, AuthError::Service(_) | AuthError::UserUnknown) {
                     error!("pam_ssh_agent_webauthn: {e}");
                 } else {
                     info!("pam_ssh_agent_webauthn: {e}");
@@ -96,7 +100,7 @@ impl PamHooks for PamSshWebauthn {
 
 /// Categorizes auth failures by the PAM return code they should map to.
 /// The discrimination matters for PAM stacks composed with
-/// `[success=ok default=ignore]` and similar patterns: admins need to
+/// `[success=done default=ignore]` and similar patterns: admins need to
 /// distinguish "this module is broken" from "this user isn't authorized"
 /// from "this module needs information it doesn't have."
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,24 @@ fn classify_io_err(e: io::Error, ctx: &str) -> AuthError {
     }
 }
 
+/// Classify an `authfile::OpenError` into an `AuthError`.
+///
+/// Most variants represent genuine misconfigurations (file owned by the
+/// wrong user, world-writable, on a per-user mount point, etc.) and map to
+/// `Service`. `Io` is delegated to `classify_io_err` so that benign cases
+/// like `NotFound` (host has not been provisioned with any keys yet) and
+/// `PermissionDenied` (e.g. an SELinux policy blocking the read) map to
+/// `InfoUnavailable` and let PAM stacks compose with `default=ignore` /
+/// `authinfo_unavail=ignore` cleanly. Without this, a missing
+/// `authorized_keys` file would be a hard lockout under the README's
+/// recommended stack.
+fn classify_open_err(e: authfile::OpenError) -> AuthError {
+    match e {
+        authfile::OpenError::Io(io_err) => classify_io_err(io_err, "read authorized_keys"),
+        other => AuthError::Service(format!("read authorized_keys: {other}")),
+    }
+}
+
 #[derive(Debug)]
 struct Config {
     key_file: String,
@@ -222,9 +240,12 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthEr
         ..Default::default()
     };
     let content = authfile::open_secure(Path::new(&config.key_file), &opts)
-        .map_err(|e| AuthError::Service(format!("read authorized_keys: {e}")))?;
+        .map_err(classify_open_err)?;
     let authorized_keys = keys::parse_authorized_keys_str(&content);
     if authorized_keys.is_empty() {
+        // The file exists, passed all safety checks, but contains no WebAuthn
+        // SK lines. Treat this the same as the file not existing at all:
+        // there is no credential to verify against, but the module is fine.
         return Err(AuthError::InfoUnavailable(format!(
             "no WebAuthn keys found in {}",
             config.key_file
@@ -255,7 +276,12 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthEr
     };
     let socket = Path::new(&socket_path);
 
-    // List agent identities
+    // List agent identities. An empty list is `InfoUnavailable` (the user
+    // has not loaded their credential into ssh-agent — fall through cleanly)
+    // rather than `AuthFail`. The asymmetry with the `tried == 0` case below
+    // is deliberate: "no keys at all" is a missing precondition, while "keys
+    // present but none match the authorized set" is a real authentication
+    // failure ("you have the wrong credential for this server").
     let agent_identities = agent::list_webauthn_identities(socket)
         .map_err(|e| classify_io_err(e, "list agent identities"))?;
     if agent_identities.is_empty() {
@@ -310,6 +336,10 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthEr
         }
     }
 
+    // Both branches are AuthFail: the agent presented WebAuthn keys but the
+    // user could not (or chose not to) prove possession of one that's listed
+    // in authorized_keys. Contrast with the empty-agent_identities branch
+    // above, which is InfoUnavailable.
     if tried == 0 {
         Err(AuthError::AuthFail(
             "no agent key matched authorized_keys".into(),
@@ -496,5 +526,73 @@ mod tests {
                 "kind {kind:?} should map to InfoUnavailable"
             );
         }
+    }
+
+    #[test]
+    fn classify_io_err_routes_agent_failure_to_info_unavailable() {
+        // `agent::list_webauthn_identities` wraps SSH_AGENT_FAILURE responses
+        // as `io::Error::other("Agent failure")`, which produces an error
+        // whose kind is implementation-defined (currently `Uncategorized`).
+        // Pin the contract so that classification doesn't accidentally land
+        // such errors in `Service`: a malfunctioning agent should let PAM
+        // stacks fall through, not lock the user out.
+        let e = io::Error::other("Agent failure");
+        assert!(
+            matches!(classify_io_err(e, "ctx"), AuthError::InfoUnavailable(_)),
+            "io::Error::other must classify as InfoUnavailable"
+        );
+    }
+
+    #[test]
+    fn classify_open_err_missing_file_is_info_unavailable() {
+        // Regression: a host with no /etc/security/authorized_keys yet
+        // (typical fresh install before any users are enrolled) must NOT
+        // produce PAM_SERVICE_ERR — that would turn the README's
+        // recommended stack into a hard lockout. NotFound and
+        // PermissionDenied both fall through to InfoUnavailable.
+        for kind in [io::ErrorKind::NotFound, io::ErrorKind::PermissionDenied] {
+            let err = authfile::OpenError::Io(io::Error::new(kind, "x"));
+            assert!(
+                matches!(classify_open_err(err), AuthError::InfoUnavailable(_)),
+                "OpenError::Io({kind:?}) should map to InfoUnavailable"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_open_err_misconfig_variants_are_service() {
+        use std::path::PathBuf;
+        let cases: Vec<authfile::OpenError> = vec![
+            authfile::OpenError::NotAbsolute(PathBuf::from("rel")),
+            authfile::OpenError::UnderUserWritableRoot {
+                path: PathBuf::from("/tmp/x"),
+                root: "/tmp/",
+            },
+            authfile::OpenError::NotRegularFile(PathBuf::from("/x")),
+            authfile::OpenError::BadOwner {
+                path: PathBuf::from("/x"),
+                actual: 1000,
+                expected: 0,
+            },
+            authfile::OpenError::BadMode {
+                path: PathBuf::from("/x"),
+                mode: 0o664,
+            },
+        ];
+        for err in cases {
+            let label = format!("{err:?}");
+            assert!(
+                matches!(classify_open_err(err), AuthError::Service(_)),
+                "{label} should map to Service"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_open_err_invalid_data_io_is_service() {
+        // E.g. canonicalize hitting a corrupted symlink chain on a broken
+        // filesystem — that's a Service-level concern, not info-missing.
+        let err = authfile::OpenError::Io(io::Error::new(io::ErrorKind::InvalidData, "x"));
+        assert!(matches!(classify_open_err(err), AuthError::Service(_)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ use log::{debug, error, info, warn};
 use pam::constants::{PamFlag, PamResultCode};
 use pam::module::{PamHandle, PamHooks};
 use std::ffi::CStr;
+use std::io;
 use std::path::Path;
 
 const CHALLENGE_SIZE: usize = 32;
@@ -57,17 +58,22 @@ impl PamHooks for PamSshWebauthn {
         };
 
         match do_authenticate(&config, handle) {
-            Ok(true) => {
+            Ok(()) => {
                 info!("pam_ssh_agent_webauthn: authentication successful");
                 PamResultCode::PAM_SUCCESS
             }
-            Ok(false) => {
-                info!("pam_ssh_agent_webauthn: no matching key");
-                PamResultCode::PAM_AUTH_ERR
-            }
             Err(e) => {
-                error!("pam_ssh_agent_webauthn: authentication failed: {e}");
-                PamResultCode::PAM_AUTH_ERR
+                let code = e.pam_code();
+                // Service errors get error!; everything else is info!. The
+                // distinction matters because admins triaging a syslog stream
+                // should see broken-config / malformed-protocol issues
+                // separately from "user denied the touch."
+                if matches!(e, AuthError::Service(_)) {
+                    error!("pam_ssh_agent_webauthn: {e}");
+                } else {
+                    info!("pam_ssh_agent_webauthn: {e}");
+                }
+                code
             }
         }
     }
@@ -85,6 +91,63 @@ impl PamHooks for PamSshWebauthn {
         // alike. Other auth-only modules (pam_google_authenticator, upstream
         // pam-ssh-agent) make the same choice for the same reason.
         PamResultCode::PAM_SUCCESS
+    }
+}
+
+/// Categorizes auth failures by the PAM return code they should map to.
+/// The discrimination matters for PAM stacks composed with
+/// `[success=ok default=ignore]` and similar patterns: admins need to
+/// distinguish "this module is broken" from "this user isn't authorized"
+/// from "this module needs information it doesn't have."
+#[derive(Debug)]
+enum AuthError {
+    /// Module is misconfigured or saw a corrupted protocol message.
+    /// Maps to `PAM_SERVICE_ERR`.
+    Service(String),
+    /// Information needed to authenticate isn't available — no agent
+    /// socket, no keys configured, agent unreachable. The module itself
+    /// is fine; PAM stacks should be able to fall through cleanly.
+    /// Maps to `PAM_AUTHINFO_UNAVAIL`.
+    InfoUnavailable(String),
+    /// User genuinely failed to prove possession (no matching key,
+    /// signature didn't verify, user denied the touch prompt).
+    /// Maps to `PAM_AUTH_ERR`.
+    AuthFail(String),
+    /// PAM did not supply the user identity. Maps to `PAM_USER_UNKNOWN`.
+    UserUnknown,
+}
+
+impl AuthError {
+    fn pam_code(&self) -> PamResultCode {
+        match self {
+            Self::Service(_) => PamResultCode::PAM_SERVICE_ERR,
+            Self::InfoUnavailable(_) => PamResultCode::PAM_AUTHINFO_UNAVAIL,
+            Self::AuthFail(_) => PamResultCode::PAM_AUTH_ERR,
+            Self::UserUnknown => PamResultCode::PAM_USER_UNKNOWN,
+        }
+    }
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Service(msg) => write!(f, "service error: {msg}"),
+            Self::InfoUnavailable(msg) => write!(f, "auth info unavailable: {msg}"),
+            Self::AuthFail(msg) => write!(f, "authentication failed: {msg}"),
+            Self::UserUnknown => write!(f, "PAM did not supply user identity"),
+        }
+    }
+}
+
+/// Classify an `io::Error` from the agent path into an `AuthError`.
+/// `InvalidData` indicates a malformed wire-format response (the agent
+/// is broken, not unreachable); everything else is treated as a transport
+/// problem — `InfoUnavailable` so PAM stacks can fall through.
+fn classify_io_err(e: io::Error, ctx: &str) -> AuthError {
+    if e.kind() == io::ErrorKind::InvalidData {
+        AuthError::Service(format!("{ctx}: malformed agent protocol: {e}"))
+    } else {
+        AuthError::InfoUnavailable(format!("{ctx}: {e}"))
     }
 }
 
@@ -127,8 +190,28 @@ fn parse_args(args: &[&CStr]) -> Result<Config, String> {
     })
 }
 
-fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<bool, Box<dyn std::error::Error>> {
-    let user = handle.get_user(None).unwrap_or_else(|_| "unknown".to_string());
+/// Outcome of a single sign-and-verify attempt. Distinguishes soft failures
+/// (try the next matching key) from hard failures (propagate).
+enum TryAuthOutcome {
+    /// Agent rejected the sign request — user denied the prompt, key not
+    /// loaded, agent policy refused.
+    Refused(String),
+    /// Agent signed but the signature didn't verify under our public key.
+    /// Try the next matching identity in case the agent presented the
+    /// wrong key.
+    VerifyFailed(String),
+    /// Transport-level I/O failure or malformed agent reply.
+    /// Caller maps via `classify_io_err` to either Service or InfoUnavailable.
+    Transport(io::Error),
+    /// Failed to generate a fresh random challenge — system entropy issue.
+    /// Maps to Service.
+    Random(String),
+}
+
+fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthError> {
+    let user = handle
+        .get_user(None)
+        .map_err(|_| AuthError::UserUnknown)?;
     info!("pam_ssh_agent_webauthn: authenticating user '{user}'");
 
     // Read authorized_keys under the OpenSSH-style safety ladder:
@@ -138,11 +221,14 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<bool, Box<
         strict_modes: config.strict_modes,
         ..Default::default()
     };
-    let content = authfile::open_secure(Path::new(&config.key_file), &opts)?;
+    let content = authfile::open_secure(Path::new(&config.key_file), &opts)
+        .map_err(|e| AuthError::Service(format!("read authorized_keys: {e}")))?;
     let authorized_keys = keys::parse_authorized_keys_str(&content);
     if authorized_keys.is_empty() {
-        debug!("No WebAuthn keys found in {}", config.key_file);
-        return Ok(false);
+        return Err(AuthError::InfoUnavailable(format!(
+            "no WebAuthn keys found in {}",
+            config.key_file
+        )));
     }
     info!(
         "Loaded {} WebAuthn key(s) from {}",
@@ -163,24 +249,27 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<bool, Box<
     // that file's integrity, not this socket path.
     let socket_path = match &config.socket_path {
         Some(path) => path.clone(),
-        None => std::env::var("SSH_AUTH_SOCK")
-            .map_err(|_| "SSH_AUTH_SOCK not set")?,
+        None => std::env::var("SSH_AUTH_SOCK").map_err(|_| {
+            AuthError::InfoUnavailable("SSH_AUTH_SOCK not set".into())
+        })?,
     };
     let socket = Path::new(&socket_path);
 
     // List agent identities
-    let agent_identities = agent::list_webauthn_identities(socket)?;
+    let agent_identities = agent::list_webauthn_identities(socket)
+        .map_err(|e| classify_io_err(e, "list agent identities"))?;
     if agent_identities.is_empty() {
-        debug!("No WebAuthn keys in agent");
-        return Ok(false);
+        return Err(AuthError::InfoUnavailable(
+            "no WebAuthn keys in agent".into(),
+        ));
     }
     info!("Found {} WebAuthn key(s) in agent", agent_identities.len());
 
     // Iterate every (agent identity × authorized key) match and try them in
-    // order. A failure on one key (user denied the prompt, signature invalid,
-    // agent returned SSH_AGENT_FAILURE, etc.) is logged and skipped — only an
-    // empty match set or all-keys-failed produces Ok(false). Mirrors standard
-    // ssh-client behavior of trying each available identity.
+    // order. A soft failure on one key (user denied the prompt, signature
+    // invalid, agent returned SSH_AGENT_FAILURE) is logged and skipped — only
+    // a transport/protocol failure or all-matches-exhausted produces an Err.
+    // Mirrors standard ssh-client behavior of trying each available identity.
     let mut tried = 0;
     for agent_id in &agent_identities {
         for auth_key in &authorized_keys {
@@ -193,56 +282,71 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<bool, Box<
                 auth_key.comment, auth_key.application
             );
             match try_authenticate(socket, auth_key, &agent_id.key_blob) {
-                Ok(true) => return Ok(true),
-                Ok(false) => continue,
-                Err(e) => {
-                    // Distinguish protocol refusal (user denied, key not
-                    // loaded, agent policy) from transport errors (broken
-                    // socket, malformed reply). Only the former should move
-                    // on silently — transport problems need to surface so
-                    // "agent is down" doesn't look like "no key matched."
-                    if let Some(agent::SignError::Transport(_)) =
-                        e.downcast_ref::<agent::SignError>()
-                    {
-                        error!(
-                            "pam_ssh_agent_webauthn: transport error talking to agent for key '{}': {e}",
-                            auth_key.comment
-                        );
-                        return Err(e);
-                    }
+                Ok(()) => return Ok(()),
+                Err(TryAuthOutcome::Refused(msg)) => {
                     warn!(
-                        "pam_ssh_agent_webauthn: key '{}' failed, trying next: {e}",
+                        "pam_ssh_agent_webauthn: key '{}' refused, trying next: {msg}",
                         auth_key.comment
                     );
+                }
+                Err(TryAuthOutcome::VerifyFailed(msg)) => {
+                    warn!(
+                        "pam_ssh_agent_webauthn: key '{}' verification failed, trying next: {msg}",
+                        auth_key.comment
+                    );
+                }
+                Err(TryAuthOutcome::Transport(e)) => {
+                    return Err(classify_io_err(
+                        e,
+                        &format!("agent sign for key '{}'", auth_key.comment),
+                    ));
+                }
+                Err(TryAuthOutcome::Random(msg)) => {
+                    return Err(AuthError::Service(format!(
+                        "challenge generation: {msg}"
+                    )));
                 }
             }
         }
     }
 
     if tried == 0 {
-        debug!("No agent key matched authorized keys");
+        Err(AuthError::AuthFail(
+            "no agent key matched authorized_keys".into(),
+        ))
     } else {
-        info!("All {tried} matching key(s) failed to authenticate");
+        Err(AuthError::AuthFail(format!(
+            "all {tried} matching key(s) failed to authenticate"
+        )))
     }
-    Ok(false)
 }
 
 fn try_authenticate(
     socket: &Path,
     key: &keys::WebAuthnPublicKey,
     key_blob: &[u8],
-) -> Result<bool, Box<dyn std::error::Error>> {
+) -> Result<(), TryAuthOutcome> {
     // Generate random challenge
     let mut challenge = [0u8; CHALLENGE_SIZE];
-    getrandom::fill(&mut challenge).map_err(|_| "Failed to generate random challenge")?;
+    getrandom::fill(&mut challenge)
+        .map_err(|e| TryAuthOutcome::Random(e.to_string()))?;
 
     // Sign via agent
-    let raw_sig = agent::sign_raw(socket, key_blob, &challenge)?;
+    let raw_sig = match agent::sign_raw(socket, key_blob, &challenge) {
+        Ok(sig) => sig,
+        Err(agent::SignError::Refused(msg)) => {
+            return Err(TryAuthOutcome::Refused(msg));
+        }
+        Err(agent::SignError::Transport(e)) => {
+            return Err(TryAuthOutcome::Transport(e));
+        }
+    };
 
     // Verify WebAuthn signature
-    webauthn::verify_webauthn_sk(key, &challenge, &raw_sig)?;
+    webauthn::verify_webauthn_sk(key, &challenge, &raw_sig)
+        .map_err(|e| TryAuthOutcome::VerifyFailed(e.to_string()))?;
 
-    Ok(true)
+    Ok(())
 }
 
 fn init_logging() {
@@ -290,16 +394,10 @@ pub fn authenticate(
                 continue;
             }
             match try_authenticate(socket_path, auth_key, &agent_id.key_blob) {
-                Ok(true) => return Ok(true),
-                Ok(false) => continue,
-                Err(e) => {
-                    if let Some(agent::SignError::Transport(_)) =
-                        e.downcast_ref::<agent::SignError>()
-                    {
-                        return Err(e);
-                    }
-                    continue;
-                }
+                Ok(()) => return Ok(true),
+                Err(TryAuthOutcome::Transport(e)) => return Err(Box::new(e)),
+                Err(TryAuthOutcome::Random(msg)) => return Err(msg.into()),
+                Err(TryAuthOutcome::Refused(_)) | Err(TryAuthOutcome::VerifyFailed(_)) => continue,
             }
         }
     }
@@ -351,5 +449,52 @@ mod tests {
     fn parse_args_rejects_invalid_strict_modes_value() {
         let err = parse(&["strict_modes=maybe"]).unwrap_err();
         assert!(err.contains("strict_modes"), "got: {err}");
+    }
+
+    #[test]
+    fn auth_error_pam_codes() {
+        assert_eq!(
+            AuthError::Service("x".into()).pam_code(),
+            PamResultCode::PAM_SERVICE_ERR
+        );
+        assert_eq!(
+            AuthError::InfoUnavailable("x".into()).pam_code(),
+            PamResultCode::PAM_AUTHINFO_UNAVAIL
+        );
+        assert_eq!(
+            AuthError::AuthFail("x".into()).pam_code(),
+            PamResultCode::PAM_AUTH_ERR
+        );
+        assert_eq!(
+            AuthError::UserUnknown.pam_code(),
+            PamResultCode::PAM_USER_UNKNOWN
+        );
+    }
+
+    #[test]
+    fn classify_io_err_routes_invalid_data_to_service() {
+        let e = io::Error::new(io::ErrorKind::InvalidData, "bad");
+        assert!(matches!(
+            classify_io_err(e, "ctx"),
+            AuthError::Service(_)
+        ));
+    }
+
+    #[test]
+    fn classify_io_err_routes_other_kinds_to_info_unavailable() {
+        for kind in [
+            io::ErrorKind::NotFound,
+            io::ErrorKind::PermissionDenied,
+            io::ErrorKind::ConnectionRefused,
+            io::ErrorKind::BrokenPipe,
+            io::ErrorKind::TimedOut,
+            io::ErrorKind::UnexpectedEof,
+        ] {
+            let e = io::Error::new(kind, "x");
+            assert!(
+                matches!(classify_io_err(e, "ctx"), AuthError::InfoUnavailable(_)),
+                "kind {kind:?} should map to InfoUnavailable"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #2.

## Summary

Replaces the catch-all `Err → PAM_AUTH_ERR` mapping in `sm_authenticate` with a typed `AuthError` that routes each failure mode to its appropriate PAM return code. This lets PAM stacks composed with `[success=done auth_err=die authinfo_unavail=ignore default=ignore]` distinguish "this user failed auth" from "this user has no agent forwarded — try password."

Also folds in the L4 finding: `get_user` failure now returns `PAM_USER_UNKNOWN` instead of silently substituting the literal string `"unknown"` — see "Behavioral changes" below.

## Mapping

| Condition | Code |
|---|---|
| Argv parse error | `PAM_SERVICE_ERR` (unchanged) |
| `SSH_AUTH_SOCK` unset and no `socket=` arg | `PAM_AUTHINFO_UNAVAIL` |
| Key file missing (`NotFound`) or unreadable (`PermissionDenied`) | `PAM_AUTHINFO_UNAVAIL` |
| Key file fails safety ladder (wrong owner/mode/path) | `PAM_SERVICE_ERR` |
| Key file present but contains no WebAuthn keys | `PAM_AUTHINFO_UNAVAIL` |
| Agent socket connect/IO error | `PAM_AUTHINFO_UNAVAIL` |
| Agent returned malformed protocol message (`io::ErrorKind::InvalidData`) | `PAM_SERVICE_ERR` |
| Agent returned `SSH_AGENT_FAILURE` for a sign | loops to next key (unchanged) |
| Agent has zero WebAuthn keys | `PAM_AUTHINFO_UNAVAIL` |
| No agent key matched authorized_keys | `PAM_AUTH_ERR` |
| All matched keys failed verification | `PAM_AUTH_ERR` |
| `getrandom` failed | `PAM_SERVICE_ERR` |
| PAM did not supply a user identity | `PAM_USER_UNKNOWN` |

## What changed

- **New `AuthError` enum** with four variants and a `pam_code()` method.
- **New `TryAuthOutcome` enum** for the inner sign/verify loop, separating soft (Refused / VerifyFailed → try next key) from hard (Transport / Random → propagate) failures.
- **`classify_io_err(e, ctx)`** routes `io::ErrorKind::InvalidData` → `Service`, anything else → `InfoUnavailable`.
- **`classify_open_err(e)`** maps `authfile::OpenError`: misconfiguration variants (`NotAbsolute`, `UnderUserWritableRoot`, `NotRegularFile`, `BadOwner`, `BadMode`) → `Service`; the `Io` variant is delegated to `classify_io_err` so a missing or unreadable file falls through cleanly.
- **`do_authenticate`** now returns `Result<(), AuthError>` instead of `Result<bool, Box<dyn Error>>`. The "no matching key" case is `Err(AuthFail(...))` rather than `Ok(false)`.
- **`try_authenticate`** returns `Result<(), TryAuthOutcome>`; the caller maps the hard variants via `classify_io_err`.
- **CLI helper `pub fn authenticate`** updated for the new `try_authenticate` signature; behavior is unchanged.
- **`sm_authenticate`** logs `Service` errors at `error!` and everything else at `info!` so admins can triage broken-config from "user denied the touch" in syslog.
- **`sm_setcred`** unchanged — `PAM_SUCCESS` for `doas` compat (out of scope per the issue).

## Behavioral changes

- **`get_user` failure** now returns `PAM_USER_UNKNOWN` instead of authenticating with the user identity `"unknown"`. The previous behavior was sloppy (the module would proceed without knowing who it was authenticating); the new behavior is strictly correct per the PAM spec. Callers that were relying on the old fallback behavior (rare — it requires PAM to fail to provide PAM_USER, which most applications don't do) will need to handle the new code.
- **Missing `authorized_keys`** now returns `PAM_AUTHINFO_UNAVAIL` instead of `PAM_AUTH_ERR`. Composes cleanly with `authinfo_unavail=ignore`. (Was previously `PAM_AUTH_ERR` via the catch-all.)
- **Empty agent identity list** now returns `PAM_AUTHINFO_UNAVAIL` (was `PAM_AUTH_ERR`).
- **`SSH_AUTH_SOCK` unset** now returns `PAM_AUTHINFO_UNAVAIL` (was `PAM_AUTH_ERR`).

## Tests

- 8 new unit tests in `src/lib.rs::tests`:
  - `auth_error_pam_codes` — every variant maps to its expected code.
  - `classify_io_err_routes_invalid_data_to_service`.
  - `classify_io_err_routes_other_kinds_to_info_unavailable` — covers `NotFound`, `PermissionDenied`, `ConnectionRefused`, `BrokenPipe`, `TimedOut`, `UnexpectedEof`.
  - `classify_io_err_routes_agent_failure_to_info_unavailable` — pins the `io::Error::other` contract for `SSH_AGENT_FAILURE` responses.
  - `classify_open_err_missing_file_is_info_unavailable` — regression test for the missing-file lockout fix.
  - `classify_open_err_misconfig_variants_are_service` — owner/mode/path misconfigs stay Service.
  - `classify_open_err_invalid_data_io_is_service` — `Io(InvalidData)` (e.g. broken FS) routes to Service.
- All existing tests still pass: 44 unit + 5 integration.

## Docs

README gains a "PAM return codes" section with the full mapping table and a stack-composition example showing how `authinfo_unavail=ignore` lets the module fall through to password auth when no agent is forwarded. Uses `success=done` (short-circuit on success) and `default=ignore` so missing-credential cases fall through cleanly.

## Test plan

- [x] `cargo test` — 44 unit + 5 integration, all green.
- [x] `cargo clippy -- -D warnings` — clean.
- [x] Manual smoke test: invoke under sudo with `SSH_AUTH_SOCK` unset → expect syslog "auth info unavailable: SSH_AUTH_SOCK not set" and PAM stack falls through.
- [x] Manual: corrupt `/etc/security/authorized_keys` permissions to 0664 → expect syslog `service error: read authorized_keys: ... is group/world-writable` and PAM denies.
- [x] Manual: rename `/etc/security/authorized_keys` aside → expect syslog "auth info unavailable: read authorized_keys: ... not found" and PAM stack falls through to password.