### PR TITLE
feat: cap sign attempts per pam_authenticate (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ To cap how many sign requests are issued per `pam_authenticate` call (mirrors Op
 auth sufficient pam_ssh_agent_webauthn.so max_attempts=1
 ```
 
-This bounds the number of user-presence prompts a misbehaving or hostile ssh-agent can force by advertising many identities whose key blobs match `authorized_keys`. Set to `1` for strict deployments where each authentication should require exactly one touch; raise it for users with many enrolled credentials. Must be `>= 1`.
+This bounds the number of user-presence prompts a misbehaving or hostile ssh-agent can force by advertising many identities whose key blobs match `authorized_keys`. Raise it for users with many enrolled credentials. Must be `>= 1`.
+
+**Note on `max_attempts=1`:** the agent controls the order of identities returned in `IDENTITIES_ANSWER`. With a cap of `1`, a buggy or hostile agent that fronts a matching-but-non-signing identity ahead of the real one will cause legitimate auths to fail (the real key is never reached). The default of `6` self-heals because iteration continues past denied keys. If you see `sign-attempt cap of 1 reached` in syslog while users hold valid credentials, raise this value.
 
 ### Authorized-keys file protection
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ To override the agent socket path (instead of `$SSH_AUTH_SOCK`):
 auth sufficient pam_ssh_agent_webauthn.so socket=/path/to/agent.sock
 ```
 
+To cap how many sign requests are issued per `pam_authenticate` call (mirrors OpenSSH's `MaxAuthTries`; default `6`):
+
+```
+auth sufficient pam_ssh_agent_webauthn.so max_attempts=1
+```
+
+This bounds the number of user-presence prompts a misbehaving or hostile ssh-agent can force by advertising many identities whose key blobs match `authorized_keys`. Set to `1` for strict deployments where each authentication should require exactly one touch; raise it for users with many enrolled credentials. Must be `>= 1`.
+
 ### Authorized-keys file protection
 
 `authorized_keys` is the trust root: each line binds an EC point and an `application` (RP-ID) string into a credential identity that root pinned at registration time. The module enforces an OpenSSH-style ladder before reading the file:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,8 +339,10 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthEr
             // A hostile agent advertising N>cap identities matching
             // authorized_keys would otherwise force N user-presence prompts;
             // record what we saw so operators can spot the pattern in syslog.
+            // Phrased to match the AuthFail message below so a single grep
+            // for `sign-attempt cap of {N} reached` finds both log lines.
             warn!(
-                "pam_ssh_agent_webauthn: sign-attempt cap reached: \
+                "pam_ssh_agent_webauthn: sign-attempt cap of {cap} reached: \
                  agent_identities={}, matched_pairs={}, attempts={}",
                 agent_identities.len(),
                 matched.len(),
@@ -542,6 +544,12 @@ pub fn authenticate_with_max_attempts(
     // See `do_authenticate` for the rationale behind iterating all matches.
     // Transport errors bubble up; protocol refusals / verification failures
     // fall through to the next match. Cap on attempts mirrors the PAM hook.
+    //
+    // Deliberately does NOT reuse `iter_attempts`: that helper emits the
+    // operator-facing WARN syslog line on cap hit, which is meaningful only
+    // in the PAM hook context (root, syslog wired up). If this helper is
+    // ever promoted out of `#[doc(hidden)]` to a supported API, switch to
+    // `iter_attempts` so embedders get the same observability.
     for (agent_id, auth_key) in matched.iter().take(max_attempts) {
         match try_authenticate(socket_path, auth_key, &agent_id.key_blob) {
             Ok(()) => return Ok(true),
@@ -593,6 +601,17 @@ mod tests {
         assert_eq!(cfg.max_attempts, 1);
         let cfg = parse(&["max_attempts=42"]).unwrap();
         assert_eq!(cfg.max_attempts, 42);
+    }
+
+    #[test]
+    fn parse_args_repeated_max_attempts_last_wins() {
+        // Pinning the silent-overwrite contract: if `max_attempts=` appears
+        // twice, the rightmost value wins (consistent with how `file=`,
+        // `socket=`, and `strict_modes=` already behave). Locks this in so
+        // a future change to "reject duplicates" doesn't break PAM stacks
+        // that rely on overlay-style arg composition.
+        let cfg = parse(&["max_attempts=1", "max_attempts=5"]).unwrap();
+        assert_eq!(cfg.max_attempts, 5);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,15 +324,7 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthEr
     // match count when the cap is hit. Both inputs are bounded (the agent
     // wire format caps the IDENTITIES_ANSWER message at 1 MiB, and
     // authorized_keys is a root-owned file), so this allocation is small.
-    let matched: Vec<(&agent::AgentIdentity, &keys::WebAuthnPublicKey)> = agent_identities
-        .iter()
-        .flat_map(|aid| {
-            authorized_keys
-                .iter()
-                .filter(move |ak| ak.key_blob == aid.key_blob)
-                .map(move |ak| (aid, ak))
-        })
-        .collect();
+    let matched = matched_pairs(&agent_identities, &authorized_keys);
 
     // Iterate matches in order, capped at config.max_attempts. A soft failure
     // on one key (user denied the prompt, signature invalid, agent returned
@@ -341,54 +333,71 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthEr
     // Mirrors standard ssh-client behavior of trying each available identity,
     // with a cap analogous to OpenSSH's MaxAuthTries.
     let cap = config.max_attempts;
-    let attempts = iter_attempts(socket, &matched, cap)?;
-
-    if attempts.succeeded {
-        return Ok(());
-    }
-
-    if attempts.hit_cap {
-        // A hostile agent advertising N>cap identities matching authorized_keys
-        // would otherwise force N user-presence prompts; record what we saw so
-        // operators can spot the pattern in syslog.
-        warn!(
-            "pam_ssh_agent_webauthn: sign-attempt cap reached: \
-             agent_identities={}, matched_pairs={}, attempts={}",
-            agent_identities.len(),
-            matched.len(),
-            attempts.tried
-        );
-        return Err(AuthError::AuthFail(format!(
-            "sign-attempt cap of {cap} reached; {} match(es) advertised",
-            matched.len()
-        )));
-    }
-
-    // Both branches are AuthFail: the agent presented WebAuthn keys but the
-    // user could not (or chose not to) prove possession of one that's listed
-    // in authorized_keys. Contrast with the empty-agent_identities branch
-    // above, which is InfoUnavailable.
-    if attempts.tried == 0 {
-        Err(AuthError::AuthFail(
+    match iter_attempts(socket, &matched, cap)? {
+        AttemptOutcome::Succeeded => Ok(()),
+        AttemptOutcome::CapHit { tried } => {
+            // A hostile agent advertising N>cap identities matching
+            // authorized_keys would otherwise force N user-presence prompts;
+            // record what we saw so operators can spot the pattern in syslog.
+            warn!(
+                "pam_ssh_agent_webauthn: sign-attempt cap reached: \
+                 agent_identities={}, matched_pairs={}, attempts={}",
+                agent_identities.len(),
+                matched.len(),
+                tried
+            );
+            Err(AuthError::AuthFail(format!(
+                "sign-attempt cap of {cap} reached; tried {tried} of {} match(es)",
+                matched.len()
+            )))
+        }
+        // Both branches are AuthFail: the agent presented WebAuthn keys but
+        // the user could not (or chose not to) prove possession of one that's
+        // listed in authorized_keys. Contrast with the empty-agent_identities
+        // branch above, which is InfoUnavailable.
+        AttemptOutcome::Exhausted { tried: 0 } => Err(AuthError::AuthFail(
             "no agent key matched authorized_keys".into(),
-        ))
-    } else {
-        Err(AuthError::AuthFail(format!(
-            "all {} matching key(s) failed to authenticate",
-            attempts.tried
-        )))
+        )),
+        AttemptOutcome::Exhausted { tried } => Err(AuthError::AuthFail(format!(
+            "all {tried} matching key(s) failed to authenticate"
+        ))),
     }
 }
 
-/// Result of iterating matched (agent ↔ authorized_keys) pairs up to a cap.
-struct AttemptOutcome {
-    /// Whether one of the attempts produced a verified signature.
-    succeeded: bool,
-    /// Number of sign requests actually issued to the agent.
-    tried: usize,
-    /// True if iteration stopped because the cap was reached, not because
-    /// matches were exhausted or one succeeded.
-    hit_cap: bool,
+/// Build the cartesian product of (agent identity × authorized key) pairs
+/// whose key blobs match exactly. Centralized so both the PAM hook path and
+/// the bundled `authenticate` helper apply the same matching rule —
+/// canonicalization changes (e.g. application-string normalization) only
+/// need updating in one place.
+fn matched_pairs<'a>(
+    agent_identities: &'a [agent::AgentIdentity],
+    authorized_keys: &'a [keys::WebAuthnPublicKey],
+) -> Vec<(&'a agent::AgentIdentity, &'a keys::WebAuthnPublicKey)> {
+    agent_identities
+        .iter()
+        .flat_map(|aid| {
+            authorized_keys
+                .iter()
+                .filter(move |ak| ak.key_blob == aid.key_blob)
+                .map(move |ak| (aid, ak))
+        })
+        .collect()
+}
+
+/// Outcome of iterating matched (agent ↔ authorized_keys) pairs up to a cap.
+/// Encoded as an enum so the three terminal states (signed, cap reached,
+/// matches exhausted) are mutually exclusive at the type level — the call
+/// site reads as an exhaustive `match` rather than two sequential `if`s.
+enum AttemptOutcome {
+    /// One of the attempts produced a verified signature. The attempt count
+    /// is not carried — the caller's only job on success is to return
+    /// `PAM_SUCCESS` / `Ok(true)`, and no log message currently consumes it.
+    Succeeded,
+    /// Iteration stopped because the cap was reached before all matches
+    /// could be tried.
+    CapHit { tried: usize },
+    /// Every available match was tried (or there were none); none succeeded.
+    Exhausted { tried: usize },
 }
 
 /// Iterate matched pairs, sending sign requests until one succeeds, the cap
@@ -402,11 +411,7 @@ fn iter_attempts(
     let mut tried = 0;
     for (agent_id, auth_key) in matched.iter() {
         if tried >= cap {
-            return Ok(AttemptOutcome {
-                succeeded: false,
-                tried,
-                hit_cap: true,
-            });
+            return Ok(AttemptOutcome::CapHit { tried });
         }
         tried += 1;
         debug!(
@@ -414,13 +419,7 @@ fn iter_attempts(
             auth_key.comment, auth_key.application
         );
         match try_authenticate(socket, auth_key, &agent_id.key_blob) {
-            Ok(()) => {
-                return Ok(AttemptOutcome {
-                    succeeded: true,
-                    tried,
-                    hit_cap: false,
-                });
-            }
+            Ok(()) => return Ok(AttemptOutcome::Succeeded),
             Err(TryAuthOutcome::Refused(msg)) => {
                 warn!(
                     "pam_ssh_agent_webauthn: key '{}' refused, trying next: {msg}",
@@ -446,11 +445,7 @@ fn iter_attempts(
             }
         }
     }
-    Ok(AttemptOutcome {
-        succeeded: false,
-        tried,
-        hit_cap: false,
-    })
+    Ok(AttemptOutcome::Exhausted { tried })
 }
 
 fn try_authenticate(
@@ -503,6 +498,10 @@ fn init_logging() {
 /// If you are embedding this crate outside the PAM hook, do not call this
 /// function with attacker-influenceable paths. Use [`authfile::open_secure`]
 /// + [`keys::parse_authorized_keys_str`] yourself.
+///
+/// `#[doc(hidden)]`: kept `pub` for the bundled examples and `tests/`
+/// integration crate, but not part of the supported API surface.
+#[doc(hidden)]
 pub fn authenticate(
     socket_path: &Path,
     key_file: &Path,
@@ -516,6 +515,10 @@ pub fn authenticate(
 /// reads the cap from the `max_attempts=N` module argument.
 ///
 /// Returns `Ok(false)` when the cap is hit without a successful signature.
+///
+/// `#[doc(hidden)]`: same caveat as [`authenticate`] — test helper, not
+/// part of the supported API surface.
+#[doc(hidden)]
 pub fn authenticate_with_max_attempts(
     socket_path: &Path,
     key_file: &Path,
@@ -534,15 +537,7 @@ pub fn authenticate_with_max_attempts(
         return Ok(false);
     }
 
-    let matched: Vec<(&agent::AgentIdentity, &keys::WebAuthnPublicKey)> = agent_identities
-        .iter()
-        .flat_map(|aid| {
-            authorized_keys
-                .iter()
-                .filter(move |ak| ak.key_blob == aid.key_blob)
-                .map(move |ak| (aid, ak))
-        })
-        .collect();
+    let matched = matched_pairs(&agent_identities, &authorized_keys);
 
     // See `do_authenticate` for the rationale behind iterating all matches.
     // Transport errors bubble up; protocol refusals / verification failures

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,10 @@
 //! * `socket=PATH` — override `$SSH_AUTH_SOCK`.
 //! * `strict_modes=yes|no` — walk ancestor dir chain checking ownership and
 //!   modes; default `yes`. Mirrors OpenSSH `StrictModes`.
+//! * `max_attempts=N` — cap on sign requests issued per `pam_authenticate`
+//!   call; default `6`. Mirrors OpenSSH `MaxAuthTries`. Bounds the user-
+//!   visible touch prompts a hostile agent can force by advertising many
+//!   identities whose blobs match `authorized_keys`.
 //!
 //! ## How it works
 //!
@@ -41,6 +45,11 @@ use std::path::Path;
 
 const CHALLENGE_SIZE: usize = 32;
 const DEFAULT_KEY_FILE: &str = "/etc/security/authorized_keys";
+/// Default cap on sign requests issued per authenticate call. Mirrors
+/// OpenSSH's `MaxAuthTries` default. Bounds the touch prompts a hostile
+/// agent can force by advertising many identities whose blobs match
+/// `authorized_keys`. Tunable per PAM config via `max_attempts=N`.
+const DEFAULT_MAX_SIGN_ATTEMPTS: usize = 6;
 
 struct PamSshWebauthn;
 pam::pam_hooks!(PamSshWebauthn);
@@ -178,12 +187,14 @@ struct Config {
     key_file: String,
     socket_path: Option<String>,
     strict_modes: bool,
+    max_attempts: usize,
 }
 
 fn parse_args(args: &[&CStr]) -> Result<Config, String> {
     let mut key_file = DEFAULT_KEY_FILE.to_string();
     let mut socket_path = None;
     let mut strict_modes = true;
+    let mut max_attempts = DEFAULT_MAX_SIGN_ATTEMPTS;
 
     for arg in args {
         let s = arg.to_str().map_err(|e| format!("Invalid arg: {e}"))?;
@@ -197,6 +208,18 @@ fn parse_args(args: &[&CStr]) -> Result<Config, String> {
                 "no" | "false" | "0" => false,
                 other => return Err(format!("Invalid strict_modes value: {other}")),
             };
+        } else if let Some(value) = s.strip_prefix("max_attempts=") {
+            // Reject 0 explicitly: a cap of 0 would never call the agent at
+            // all, turning the module into an unconditional auth failure.
+            // That's almost certainly a config mistake, so refuse it loudly
+            // rather than silently locking everyone out.
+            let n: usize = value
+                .parse()
+                .map_err(|_| format!("Invalid max_attempts value: {value}"))?;
+            if n == 0 {
+                return Err(format!("Invalid max_attempts value: {value} (must be >= 1)"));
+            }
+            max_attempts = n;
         } else {
             // Refuse unknown args rather than silently dropping them: a typo
             // like `strictmodes=no` instead of `strict_modes=no` would
@@ -209,6 +232,7 @@ fn parse_args(args: &[&CStr]) -> Result<Config, String> {
         key_file,
         socket_path,
         strict_modes,
+        max_attempts,
     })
 }
 
@@ -295,64 +319,138 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthEr
     }
     info!("Found {} WebAuthn key(s) in agent", agent_identities.len());
 
-    // Iterate every (agent identity × authorized key) match and try them in
-    // order. A soft failure on one key (user denied the prompt, signature
-    // invalid, agent returned SSH_AGENT_FAILURE) is logged and skipped — only
-    // a transport/protocol failure or all-matches-exhausted produces an Err.
-    // Mirrors standard ssh-client behavior of trying each available identity.
-    let mut tried = 0;
-    for agent_id in &agent_identities {
-        for auth_key in &authorized_keys {
-            if agent_id.key_blob != auth_key.key_blob {
-                continue;
-            }
-            tried += 1;
-            debug!(
-                "Trying matched key: {} (app: {})",
-                auth_key.comment, auth_key.application
-            );
-            match try_authenticate(socket, auth_key, &agent_id.key_blob) {
-                Ok(()) => return Ok(()),
-                Err(TryAuthOutcome::Refused(msg)) => {
-                    warn!(
-                        "pam_ssh_agent_webauthn: key '{}' refused, trying next: {msg}",
-                        auth_key.comment
-                    );
-                }
-                Err(TryAuthOutcome::VerifyFailed(msg)) => {
-                    warn!(
-                        "pam_ssh_agent_webauthn: key '{}' verification failed, trying next: {msg}",
-                        auth_key.comment
-                    );
-                }
-                Err(TryAuthOutcome::Transport(e)) => {
-                    return Err(classify_io_err(
-                        e,
-                        &format!("agent sign for key '{}'", auth_key.comment),
-                    ));
-                }
-                Err(TryAuthOutcome::Random(msg)) => {
-                    return Err(AuthError::Service(format!(
-                        "challenge generation: {msg}"
-                    )));
-                }
-            }
-        }
+    // Materialize the set of (agent identity × authorized key) matches up
+    // front so we can both enforce a cap on attempts and report the total
+    // match count when the cap is hit. Both inputs are bounded (the agent
+    // wire format caps the IDENTITIES_ANSWER message at 1 MiB, and
+    // authorized_keys is a root-owned file), so this allocation is small.
+    let matched: Vec<(&agent::AgentIdentity, &keys::WebAuthnPublicKey)> = agent_identities
+        .iter()
+        .flat_map(|aid| {
+            authorized_keys
+                .iter()
+                .filter(move |ak| ak.key_blob == aid.key_blob)
+                .map(move |ak| (aid, ak))
+        })
+        .collect();
+
+    // Iterate matches in order, capped at config.max_attempts. A soft failure
+    // on one key (user denied the prompt, signature invalid, agent returned
+    // SSH_AGENT_FAILURE) is logged and skipped — only a transport/protocol
+    // failure or hitting the cap / exhausting matches produces an Err.
+    // Mirrors standard ssh-client behavior of trying each available identity,
+    // with a cap analogous to OpenSSH's MaxAuthTries.
+    let cap = config.max_attempts;
+    let attempts = iter_attempts(socket, &matched, cap)?;
+
+    if attempts.succeeded {
+        return Ok(());
+    }
+
+    if attempts.hit_cap {
+        // A hostile agent advertising N>cap identities matching authorized_keys
+        // would otherwise force N user-presence prompts; record what we saw so
+        // operators can spot the pattern in syslog.
+        warn!(
+            "pam_ssh_agent_webauthn: sign-attempt cap reached: \
+             agent_identities={}, matched_pairs={}, attempts={}",
+            agent_identities.len(),
+            matched.len(),
+            attempts.tried
+        );
+        return Err(AuthError::AuthFail(format!(
+            "sign-attempt cap of {cap} reached; {} match(es) advertised",
+            matched.len()
+        )));
     }
 
     // Both branches are AuthFail: the agent presented WebAuthn keys but the
     // user could not (or chose not to) prove possession of one that's listed
     // in authorized_keys. Contrast with the empty-agent_identities branch
     // above, which is InfoUnavailable.
-    if tried == 0 {
+    if attempts.tried == 0 {
         Err(AuthError::AuthFail(
             "no agent key matched authorized_keys".into(),
         ))
     } else {
         Err(AuthError::AuthFail(format!(
-            "all {tried} matching key(s) failed to authenticate"
+            "all {} matching key(s) failed to authenticate",
+            attempts.tried
         )))
     }
+}
+
+/// Result of iterating matched (agent ↔ authorized_keys) pairs up to a cap.
+struct AttemptOutcome {
+    /// Whether one of the attempts produced a verified signature.
+    succeeded: bool,
+    /// Number of sign requests actually issued to the agent.
+    tried: usize,
+    /// True if iteration stopped because the cap was reached, not because
+    /// matches were exhausted or one succeeded.
+    hit_cap: bool,
+}
+
+/// Iterate matched pairs, sending sign requests until one succeeds, the cap
+/// is reached, or the matches are exhausted. Transport / random-source
+/// failures bubble up as `AuthError`.
+fn iter_attempts(
+    socket: &Path,
+    matched: &[(&agent::AgentIdentity, &keys::WebAuthnPublicKey)],
+    cap: usize,
+) -> Result<AttemptOutcome, AuthError> {
+    let mut tried = 0;
+    for (agent_id, auth_key) in matched.iter() {
+        if tried >= cap {
+            return Ok(AttemptOutcome {
+                succeeded: false,
+                tried,
+                hit_cap: true,
+            });
+        }
+        tried += 1;
+        debug!(
+            "Trying matched key: {} (app: {})",
+            auth_key.comment, auth_key.application
+        );
+        match try_authenticate(socket, auth_key, &agent_id.key_blob) {
+            Ok(()) => {
+                return Ok(AttemptOutcome {
+                    succeeded: true,
+                    tried,
+                    hit_cap: false,
+                });
+            }
+            Err(TryAuthOutcome::Refused(msg)) => {
+                warn!(
+                    "pam_ssh_agent_webauthn: key '{}' refused, trying next: {msg}",
+                    auth_key.comment
+                );
+            }
+            Err(TryAuthOutcome::VerifyFailed(msg)) => {
+                warn!(
+                    "pam_ssh_agent_webauthn: key '{}' verification failed, trying next: {msg}",
+                    auth_key.comment
+                );
+            }
+            Err(TryAuthOutcome::Transport(e)) => {
+                return Err(classify_io_err(
+                    e,
+                    &format!("agent sign for key '{}'", auth_key.comment),
+                ));
+            }
+            Err(TryAuthOutcome::Random(msg)) => {
+                return Err(AuthError::Service(format!(
+                    "challenge generation: {msg}"
+                )));
+            }
+        }
+    }
+    Ok(AttemptOutcome {
+        succeeded: false,
+        tried,
+        hit_cap: false,
+    })
 }
 
 fn try_authenticate(
@@ -409,6 +507,23 @@ pub fn authenticate(
     socket_path: &Path,
     key_file: &Path,
 ) -> Result<bool, Box<dyn std::error::Error>> {
+    authenticate_with_max_attempts(socket_path, key_file, DEFAULT_MAX_SIGN_ATTEMPTS)
+}
+
+/// Like [`authenticate`] but with a caller-supplied cap on how many sign
+/// requests are issued to the agent. Used by integration tests to exercise
+/// the cap behavior; production callers should use the PAM hook, which
+/// reads the cap from the `max_attempts=N` module argument.
+///
+/// Returns `Ok(false)` when the cap is hit without a successful signature.
+pub fn authenticate_with_max_attempts(
+    socket_path: &Path,
+    key_file: &Path,
+    max_attempts: usize,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    if max_attempts == 0 {
+        return Err("max_attempts must be >= 1".into());
+    }
     let authorized_keys = keys::parse_authorized_keys(key_file)?;
     if authorized_keys.is_empty() {
         return Ok(false);
@@ -419,20 +534,25 @@ pub fn authenticate(
         return Ok(false);
     }
 
+    let matched: Vec<(&agent::AgentIdentity, &keys::WebAuthnPublicKey)> = agent_identities
+        .iter()
+        .flat_map(|aid| {
+            authorized_keys
+                .iter()
+                .filter(move |ak| ak.key_blob == aid.key_blob)
+                .map(move |ak| (aid, ak))
+        })
+        .collect();
+
     // See `do_authenticate` for the rationale behind iterating all matches.
     // Transport errors bubble up; protocol refusals / verification failures
-    // fall through to the next match.
-    for agent_id in &agent_identities {
-        for auth_key in &authorized_keys {
-            if agent_id.key_blob != auth_key.key_blob {
-                continue;
-            }
-            match try_authenticate(socket_path, auth_key, &agent_id.key_blob) {
-                Ok(()) => return Ok(true),
-                Err(TryAuthOutcome::Transport(e)) => return Err(Box::new(e)),
-                Err(TryAuthOutcome::Random(msg)) => return Err(msg.into()),
-                Err(TryAuthOutcome::Refused(_)) | Err(TryAuthOutcome::VerifyFailed(_)) => continue,
-            }
+    // fall through to the next match. Cap on attempts mirrors the PAM hook.
+    for (agent_id, auth_key) in matched.iter().take(max_attempts) {
+        match try_authenticate(socket_path, auth_key, &agent_id.key_blob) {
+            Ok(()) => return Ok(true),
+            Err(TryAuthOutcome::Transport(e)) => return Err(Box::new(e)),
+            Err(TryAuthOutcome::Random(msg)) => return Err(msg.into()),
+            Err(TryAuthOutcome::Refused(_)) | Err(TryAuthOutcome::VerifyFailed(_)) => continue,
         }
     }
 
@@ -460,14 +580,34 @@ mod tests {
         assert_eq!(cfg.key_file, DEFAULT_KEY_FILE);
         assert!(cfg.socket_path.is_none());
         assert!(cfg.strict_modes);
+        assert_eq!(cfg.max_attempts, DEFAULT_MAX_SIGN_ATTEMPTS);
     }
 
     #[test]
     fn parse_args_known_keys() {
-        let cfg = parse(&["file=/x", "socket=/y", "strict_modes=no"]).unwrap();
+        let cfg = parse(&["file=/x", "socket=/y", "strict_modes=no", "max_attempts=3"]).unwrap();
         assert_eq!(cfg.key_file, "/x");
         assert_eq!(cfg.socket_path.as_deref(), Some("/y"));
         assert!(!cfg.strict_modes);
+        assert_eq!(cfg.max_attempts, 3);
+    }
+
+    #[test]
+    fn parse_args_max_attempts_overrides_default() {
+        let cfg = parse(&["max_attempts=1"]).unwrap();
+        assert_eq!(cfg.max_attempts, 1);
+        let cfg = parse(&["max_attempts=42"]).unwrap();
+        assert_eq!(cfg.max_attempts, 42);
+    }
+
+    #[test]
+    fn parse_args_rejects_invalid_max_attempts() {
+        // Zero would silently turn the module into an unconditional fail —
+        // refuse it. Negatives and non-numerics are typos and equally bad.
+        for bad in ["max_attempts=0", "max_attempts=-1", "max_attempts=abc", "max_attempts="] {
+            let err = parse(&[bad]).expect_err(&format!("expected error for {bad}"));
+            assert!(err.contains("max_attempts"), "wrong error for {bad}: {err}");
+        }
     }
 
     #[test]

--- a/tests/webauthn_roundtrip.rs
+++ b/tests/webauthn_roundtrip.rs
@@ -455,3 +455,188 @@ fn test_no_matching_key() {
     assert!(result.is_ok());
     assert!(!result.unwrap(), "should return false when no key matches");
 }
+
+/// Mock agent that advertises two keys (both denying via SSH_AGENT_FAILURE)
+/// and counts how many sign requests it has serviced.
+fn run_counting_deny_agent(
+    listener: UnixListener,
+    key_blobs: Vec<Vec<u8>>,
+    sign_count: Arc<std::sync::atomic::AtomicUsize>,
+    stop: Arc<AtomicBool>,
+) {
+    listener.set_nonblocking(true).expect("set_nonblocking failed");
+
+    while !stop.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                stream.set_nonblocking(false).unwrap();
+                stream
+                    .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                    .unwrap();
+
+                let mut len_buf = [0u8; 4];
+                if stream.read_exact(&mut len_buf).is_err() {
+                    continue;
+                }
+                let msg_len = u32::from_be_bytes(len_buf) as usize;
+                let mut msg = vec![0u8; msg_len];
+                if stream.read_exact(&mut msg).is_err() {
+                    continue;
+                }
+
+                match msg[0] {
+                    SSH_AGENTC_REQUEST_IDENTITIES => {
+                        let mut response = Vec::new();
+                        response.push(SSH_AGENT_IDENTITIES_ANSWER);
+                        response.extend(&(key_blobs.len() as u32).to_be_bytes());
+                        for (i, blob) in key_blobs.iter().enumerate() {
+                            write_ssh_string(&mut response, blob);
+                            let comment = format!("deny-key-{i}");
+                            write_ssh_string(&mut response, comment.as_bytes());
+                        }
+
+                        let len = (response.len() as u32).to_be_bytes();
+                        stream.write_all(&len).unwrap();
+                        stream.write_all(&response).unwrap();
+                        stream.flush().unwrap();
+                    }
+                    SSH_AGENTC_SIGN_REQUEST => {
+                        sign_count.fetch_add(1, Ordering::Relaxed);
+                        // Always refuse — we want to verify the cap stops the
+                        // module from issuing more sign requests, not whether
+                        // it picks the "right" key.
+                        let response = vec![5u8]; // SSH_AGENT_FAILURE
+
+                        let len = (response.len() as u32).to_be_bytes();
+                        stream.write_all(&len).unwrap();
+                        stream.write_all(&response).unwrap();
+                        stream.flush().unwrap();
+                    }
+                    _ => {}
+                }
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+#[test]
+fn test_max_attempts_caps_sign_requests() {
+    // Two matching keys, both refusing. With cap=1 the module must stop after
+    // a single sign request — the cap counts attempts (not just refusals), so
+    // a hostile agent advertising N matching keys cannot force N touch
+    // prompts. Mirrors OpenSSH MaxAuthTries semantics.
+    let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let key_a = SigningKey::from_bytes(&TEST_KEY_BYTES.into()).unwrap();
+    let blob_a = make_webauthn_key_blob(&key_a);
+
+    let key_b_bytes: [u8; 32] = [
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+        0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8a, 0x8b, 0x8c, 0x8d, 0x8e,
+        0x8f, 0x90,
+    ];
+    let key_b = SigningKey::from_bytes(&key_b_bytes.into()).unwrap();
+    let blob_b = make_webauthn_key_blob(&key_b);
+
+    let key_file = std::env::temp_dir().join(format!(
+        "pam_webauthn_test_cap_keys_{}_{id}.pub",
+        std::process::id()
+    ));
+    let line_a = format!("{WEBAUTHN_SK_ALGO} {} key-a\n", BASE64_STANDARD.encode(&blob_a));
+    let line_b = format!("{WEBAUTHN_SK_ALGO} {} key-b\n", BASE64_STANDARD.encode(&blob_b));
+    std::fs::write(&key_file, format!("{line_a}{line_b}")).unwrap();
+
+    let socket_path = std::env::temp_dir().join(format!(
+        "pam_webauthn_test_cap_agent_{}_{id}.sock",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&socket_path);
+    let listener = UnixListener::bind(&socket_path).unwrap();
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_clone = stop.clone();
+    let sign_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let sign_count_clone = sign_count.clone();
+
+    let blobs = vec![blob_a.clone(), blob_b.clone()];
+    let thread = std::thread::spawn(move || {
+        run_counting_deny_agent(listener, blobs, sign_count_clone, stop_clone);
+    });
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let result = pam_ssh_agent_webauthn::authenticate_with_max_attempts(
+        &socket_path,
+        &key_file,
+        1,
+    );
+    let observed = sign_count.load(Ordering::Relaxed);
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = thread.join();
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(&key_file);
+
+    assert!(matches!(result, Ok(false)), "expected Ok(false), got {result:?}");
+    assert_eq!(observed, 1, "cap=1 must produce exactly 1 sign request, got {observed}");
+}
+
+#[test]
+fn test_cap_not_hit_when_match_succeeds_within_limit() {
+    // Two matching keys; the first is denied, the second signs successfully.
+    // With cap=2 we still authenticate cleanly — the cap is a ceiling, not a
+    // floor, and must not interfere with normal multi-key iteration.
+    // Reuses run_skip_first_agent: first matched key returns SSH_AGENT_FAILURE,
+    // second produces a valid signature.
+    let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let fail_key = SigningKey::from_bytes(&TEST_KEY_BYTES.into()).unwrap();
+    let fail_blob = make_webauthn_key_blob(&fail_key);
+
+    let succeed_key_bytes: [u8; 32] = [
+        0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf,
+        0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe,
+        0xbf, 0xc0,
+    ];
+    let succeed_key = SigningKey::from_bytes(&succeed_key_bytes.into()).unwrap();
+    let succeed_blob = make_webauthn_key_blob(&succeed_key);
+
+    let key_file = std::env::temp_dir().join(format!(
+        "pam_webauthn_test_cap_succeed_keys_{}_{id}.pub",
+        std::process::id()
+    ));
+    let line1 = format!("{WEBAUTHN_SK_ALGO} {} deny-key\n", BASE64_STANDARD.encode(&fail_blob));
+    let line2 = format!("{WEBAUTHN_SK_ALGO} {} allow-key\n", BASE64_STANDARD.encode(&succeed_blob));
+    std::fs::write(&key_file, format!("{line1}{line2}")).unwrap();
+
+    let socket_path = std::env::temp_dir().join(format!(
+        "pam_webauthn_test_cap_succeed_agent_{}_{id}.sock",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&socket_path);
+    let listener = UnixListener::bind(&socket_path).unwrap();
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_clone = stop.clone();
+
+    let fail_blob_clone = fail_blob.clone();
+    let succeed_blob_clone = succeed_blob.clone();
+    let thread = std::thread::spawn(move || {
+        run_skip_first_agent(listener, fail_blob_clone, succeed_key, succeed_blob_clone, stop_clone);
+    });
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let result = pam_ssh_agent_webauthn::authenticate_with_max_attempts(
+        &socket_path,
+        &key_file,
+        2,
+    );
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = thread.join();
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(&key_file);
+
+    assert!(matches!(result, Ok(true)), "expected Ok(true), got {result:?}");
+}

--- a/tests/webauthn_roundtrip.rs
+++ b/tests/webauthn_roundtrip.rs
@@ -285,6 +285,7 @@ fn run_skip_first_agent(
     fail_key_blob: Vec<u8>,
     succeed_signing_key: SigningKey,
     succeed_key_blob: Vec<u8>,
+    sign_count: Arc<std::sync::atomic::AtomicUsize>,
     stop: Arc<AtomicBool>,
 ) {
     listener.set_nonblocking(true).expect("set_nonblocking failed");
@@ -323,6 +324,7 @@ fn run_skip_first_agent(
                         stream.flush().unwrap();
                     }
                     SSH_AGENTC_SIGN_REQUEST => {
+                        sign_count.fetch_add(1, Ordering::Relaxed);
                         let mut reader: &[u8] = &msg[1..];
                         let requested_key = read_ssh_bytes(&mut reader).unwrap_or(b"");
                         let data = read_ssh_bytes(&mut reader).unwrap_or(b"");
@@ -393,8 +395,10 @@ fn test_skip_failing_key_then_succeed() {
 
     let fail_blob_clone = fail_blob.clone();
     let succeed_blob_clone = succeed_blob.clone();
+    let sign_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let sign_count_clone = sign_count.clone();
     let thread = std::thread::spawn(move || {
-        run_skip_first_agent(listener, fail_blob_clone, succeed_key, succeed_blob_clone, stop_clone);
+        run_skip_first_agent(listener, fail_blob_clone, succeed_key, succeed_blob_clone, sign_count_clone, stop_clone);
     });
     std::thread::sleep(std::time::Duration::from_millis(50));
 
@@ -406,6 +410,11 @@ fn test_skip_failing_key_then_succeed() {
     let _ = std::fs::remove_file(&key_file);
 
     assert!(matches!(result, Ok(true)), "expected Ok(true), got {result:?}");
+    assert_eq!(
+        sign_count.load(Ordering::Relaxed),
+        2,
+        "expected 2 sign requests (1 denied + 1 accepted)"
+    );
 }
 
 #[test]
@@ -622,8 +631,10 @@ fn test_cap_not_hit_when_match_succeeds_within_limit() {
 
     let fail_blob_clone = fail_blob.clone();
     let succeed_blob_clone = succeed_blob.clone();
+    let sign_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let sign_count_clone = sign_count.clone();
     let thread = std::thread::spawn(move || {
-        run_skip_first_agent(listener, fail_blob_clone, succeed_key, succeed_blob_clone, stop_clone);
+        run_skip_first_agent(listener, fail_blob_clone, succeed_key, succeed_blob_clone, sign_count_clone, stop_clone);
     });
     std::thread::sleep(std::time::Duration::from_millis(50));
 
@@ -639,4 +650,75 @@ fn test_cap_not_hit_when_match_succeeds_within_limit() {
     let _ = std::fs::remove_file(&key_file);
 
     assert!(matches!(result, Ok(true)), "expected Ok(true), got {result:?}");
+    assert_eq!(sign_count.load(Ordering::Relaxed), 2, "expected 2 sign requests");
+}
+
+#[test]
+fn test_cap_blocks_otherwise_succeeding_key() {
+    // Two matched keys: the first is denied (SSH_AGENT_FAILURE), the second
+    // *would* sign successfully if reached. With cap=1 the module must stop
+    // after the denied first attempt — proving the cap is doing security
+    // work (actively preventing an auth that would otherwise succeed) rather
+    // than just shortening iteration over already-failing keys.
+    //
+    // This is the pathological case the cap is designed for: a hostile agent
+    // controlling identity order can DoS a legitimate user at cap=1 by
+    // fronting a non-signing identity ahead of the real one. See the README
+    // caveat on raising the cap above 1 if this pattern shows up in syslog.
+    let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let fail_key = SigningKey::from_bytes(&TEST_KEY_BYTES.into()).unwrap();
+    let fail_blob = make_webauthn_key_blob(&fail_key);
+
+    let succeed_key_bytes: [u8; 32] = [
+        0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf,
+        0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee,
+        0xef, 0xf0,
+    ];
+    let succeed_key = SigningKey::from_bytes(&succeed_key_bytes.into()).unwrap();
+    let succeed_blob = make_webauthn_key_blob(&succeed_key);
+
+    let key_file = std::env::temp_dir().join(format!(
+        "pam_webauthn_test_cap_blocks_keys_{}_{id}.pub",
+        std::process::id()
+    ));
+    let line1 = format!("{WEBAUTHN_SK_ALGO} {} deny-key\n", BASE64_STANDARD.encode(&fail_blob));
+    let line2 = format!("{WEBAUTHN_SK_ALGO} {} allow-key\n", BASE64_STANDARD.encode(&succeed_blob));
+    std::fs::write(&key_file, format!("{line1}{line2}")).unwrap();
+
+    let socket_path = std::env::temp_dir().join(format!(
+        "pam_webauthn_test_cap_blocks_agent_{}_{id}.sock",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&socket_path);
+    let listener = UnixListener::bind(&socket_path).unwrap();
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_clone = stop.clone();
+    let sign_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let sign_count_clone = sign_count.clone();
+
+    let fail_blob_clone = fail_blob.clone();
+    let succeed_blob_clone = succeed_blob.clone();
+    let thread = std::thread::spawn(move || {
+        run_skip_first_agent(listener, fail_blob_clone, succeed_key, succeed_blob_clone, sign_count_clone, stop_clone);
+    });
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let result = pam_ssh_agent_webauthn::authenticate_with_max_attempts(
+        &socket_path,
+        &key_file,
+        1,
+    );
+    let observed = sign_count.load(Ordering::Relaxed);
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = thread.join();
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(&key_file);
+
+    assert!(matches!(result, Ok(false)), "expected Ok(false), got {result:?}");
+    assert_eq!(
+        observed, 1,
+        "cap=1 must stop iteration after 1 sign request even though the second key would have signed; got {observed}"
+    );
 }


### PR DESCRIPTION
## Summary

Closes #3. Adds an OpenSSH-`MaxAuthTries`-style cap on the number of sign requests issued per `pam_authenticate` call so a misbehaving or hostile ssh-agent cannot force unbounded user-presence prompts by advertising many WebAuthn identities whose blobs match `authorized_keys`.

- New `DEFAULT_MAX_SIGN_ATTEMPTS = 6` (mirrors OpenSSH default).
- New PAM module argument `max_attempts=N` (must be `>= 1`).
- `do_authenticate` materializes the matched (agent ↔ authorized_keys) pairs, then iterates with a cap; on cap hit it logs `warn!` with `(agent_identities, matched_pairs, attempts)` and returns `PAM_AUTH_ERR`.
- Cap counts attempts (not just refusals) — a hostile agent advertising 1000 matching keys is capped at the configured number of prompts even if every prompt is genuinely declined.
- New `pub fn authenticate_with_max_attempts(socket, key_file, max)` for tests/examples; existing `authenticate` delegates with the default.
- README documents the new arg.

Wall-clock timeout is intentionally out of scope per the issue — sudo / sshd / login already enforce one, and the per-socket-op timeout in `agent.rs:27` covers hung-agent IO.

## Test plan

- [x] `cargo test` — 46 lib + 7 integration tests pass.
- [x] `cargo clippy --lib --tests -- -D warnings` clean.
- [x] New unit tests: `max_attempts=N` parsing accepted; `0`, negatives, non-numeric, empty rejected.
- [x] New integration test `test_max_attempts_caps_sign_requests`: counting mock agent with 2 matched-and-refusing keys + cap=1 sees exactly 1 sign request.
- [x] New integration test `test_cap_not_hit_when_match_succeeds_within_limit`: 2 matched keys, second succeeds, cap=2 → `Ok(true)`.
- [x] Existing `test_skip_failing_key_then_succeed` still passes (covers the default-cap multi-key iteration path).