### PR TITLE
chore(ci): bump JS-based actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Lint & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       version: ${{ steps.set.outputs.version }}
       sha: ${{ steps.commit.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
@@ -181,7 +181,7 @@ jobs:
             arch: arm64
             cross: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.sha }}
 
@@ -230,7 +230,7 @@ jobs:
           echo "artifact=${ARTIFACT}" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.rename.outputs.artifact }}
           path: ${{ steps.rename.outputs.artifact }}
@@ -240,13 +240,13 @@ jobs:
     needs: [prepare, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.sha }}
           fetch-depth: 0
 
       - name: Download prebuilt binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: binaries
           merge-multiple: true


### PR DESCRIPTION
GitHub is deprecating Node.js 20 on hosted runners — Node 20 will be the default until 2026-06-02 and removed on 2026-09-16. Upgrading the JavaScript-based actions to their Node-24 majors silences the warning and keeps us off the removal path.

## Changes

| Action | Old | New | Why |
|---|---|---|---|
| \`actions/checkout\` | \`v4\` | \`v6\` | v5 moved to Node 24. v6 also moves credential persistence into a separate file (transparent for our usage). |
| \`actions/upload-artifact\` | \`v4\` | \`v7\` | v6 moved to Node 24. v7 adds opt-in \`archive: false\` for direct uploads (we don't use it). |
| \`actions/download-artifact\` | \`v4\` | \`v8\` | v5 changed by-ID download paths (we download by name with \`merge-multiple: true\` — unaffected). v7 moved to Node 24. v8 makes hash-mismatch fatal by default — a security-positive default that doesn't change our happy path. |

Not touched:

- \`Swatinem/rust-cache@v2\` — already on Node 24 in latest patch (\`v2.9.1\`); the floating \`@v2\` ref auto-resolves.
- \`dtolnay/rust-toolchain@stable\` — composite action (shell), not a JS action.

I read the v5/v6/v7/v8 release notes for each upgraded action and confirmed none of the breaking changes affect our actual usage.

## Test plan

- [x] \`gh api\` confirms \`v6/v7/v8\` of each upgraded action declares \`runs.using: node24\`.
- [x] CI runs green on this branch (will show in checks).
- [x] Next release run via \`workflow_dispatch\` no longer logs the Node 20 deprecation warning.