### PR TITLE
chore(release): rename .so artifacts to match PAM install target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,7 @@ jobs:
         id: rename
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
-          ARTIFACT="pam-ssh-agent-webauthn_${VERSION}_${{ matrix.arch }}.so"
+          ARTIFACT="pam_ssh_agent_webauthn-${VERSION}-${{ matrix.arch }}.so"
           cp target/${{ matrix.target }}/release/libpam_ssh_agent_webauthn.so "${ARTIFACT}"
           echo "artifact=${ARTIFACT}" >> "$GITHUB_OUTPUT"
 
@@ -287,13 +287,13 @@ jobs:
             echo "Prebuilt \`.so\` modules are available for common targets. Download the one matching your architecture and copy it into place:"
             echo ""
             echo "\`\`\`bash"
-            echo "sudo cp pam-ssh-agent-webauthn_${VERSION}_amd64.so /usr/lib/x86_64-linux-gnu/security/pam_ssh_agent_webauthn.so"
+            echo "sudo cp pam_ssh_agent_webauthn-${VERSION}-amd64.so /usr/lib/x86_64-linux-gnu/security/pam_ssh_agent_webauthn.so"
             echo "\`\`\`"
             echo ""
             echo "| File | Target |"
             echo "|------|--------|"
-            echo "| \`pam-ssh-agent-webauthn_${VERSION}_amd64.so\` | x86_64 Linux (glibc, Ubuntu 22.04+, Debian 12+, RHEL 9+) |"
-            echo "| \`pam-ssh-agent-webauthn_${VERSION}_arm64.so\` | ARM64 Linux (glibc, Ubuntu 22.04+, Debian 12+, Graviton) |"
+            echo "| \`pam_ssh_agent_webauthn-${VERSION}-amd64.so\` | x86_64 Linux (glibc, Ubuntu 22.04+, Debian 12+, RHEL 9+) |"
+            echo "| \`pam_ssh_agent_webauthn-${VERSION}-arm64.so\` | ARM64 Linux (glibc, Ubuntu 22.04+, Debian 12+, Graviton) |"
             echo ""
             echo "These are dynamically linked against \`libpam\` and \`libc\` (glibc 2.35+). Built on Ubuntu 22.04."
             echo ""
@@ -322,10 +322,10 @@ jobs:
           gh release create "v${VERSION}" \
             --title "pam-ssh-agent-webauthn ${VERSION}" \
             --notes-file /tmp/release-notes.md \
-            binaries/pam-ssh-agent-webauthn_${VERSION}_amd64.so \
-            binaries/pam-ssh-agent-webauthn_${VERSION}_amd64.so.sha256 \
-            binaries/pam-ssh-agent-webauthn_${VERSION}_arm64.so \
-            binaries/pam-ssh-agent-webauthn_${VERSION}_arm64.so.sha256 \
+            binaries/pam_ssh_agent_webauthn-${VERSION}-amd64.so \
+            binaries/pam_ssh_agent_webauthn-${VERSION}-amd64.so.sha256 \
+            binaries/pam_ssh_agent_webauthn-${VERSION}-arm64.so \
+            binaries/pam_ssh_agent_webauthn-${VERSION}-arm64.so.sha256 \
             pam-ssh-agent-webauthn_${VERSION}.zip \
             pam-ssh-agent-webauthn_${VERSION}.zip.sha256 \
             pam-ssh-agent-webauthn_${VERSION}.tar.gz \


### PR DESCRIPTION
## Summary

Released `.so` artifacts were named `pam-ssh-agent-webauthn_${VERSION}_${arch}.so` (Debian-package style — hyphens in the name, `_` as separator), but the PAM install target uses underscores (`pam_ssh_agent_webauthn.so`, matching the `[lib] name` and PAM's own `pam_<name>.so` convention). That meant the install snippet had to silently rename hyphens → underscores during `cp`, which is what surfaced the inconsistency.

This PR renames released `.so` artifacts to `pam_ssh_agent_webauthn-${VERSION}-${arch}.so` so the base name equals the install target verbatim.

| Where | Before | After |
|---|---|---|
| Released `.so` | `pam-ssh-agent-webauthn_${VERSION}_${arch}.so` | `pam_ssh_agent_webauthn-${VERSION}-${arch}.so` |
| Local cargo build (unchanged) | `target/release/libpam_ssh_agent_webauthn.so` | `target/release/libpam_ssh_agent_webauthn.so` |
| Source archive (unchanged) | `pam-ssh-agent-webauthn_${VERSION}.tar.gz` | `pam-ssh-agent-webauthn_${VERSION}.tar.gz` |
| PAM install target (unchanged) | `/usr/lib/.../pam_ssh_agent_webauthn.so` | `/usr/lib/.../pam_ssh_agent_webauthn.so` |

Source archives intentionally keep the hyphenated crate-name + `_VERSION` shape, because they extract to a directory that should match the cargo crate name (`pam-ssh-agent-webauthn`).

README needs no changes — it only documents local cargo builds (which still emit `libpam_ssh_agent_webauthn.so`) and the install target name is unchanged.

## Test plan

- [ ] Tag a dry-run release on a fork (or push a `v*-rc` tag) and verify the workflow uploads `pam_ssh_agent_webauthn-${VERSION}-amd64.so` and `pam_ssh_agent_webauthn-${VERSION}-arm64.so` (plus `.sha256` siblings) to the GitHub release
- [ ] Confirm release notes render the new install snippet: `sudo cp pam_ssh_agent_webauthn-${VERSION}-amd64.so /usr/lib/x86_64-linux-gnu/security/pam_ssh_agent_webauthn.so`
- [ ] Confirm source archives still publish as `pam-ssh-agent-webauthn_${VERSION}.{tar.gz,zip}`