### PR TITLE
fix(pam): tolerate pam_get_user failure to work around pam-bindings release-build bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ The module distinguishes failure modes so PAM stacks can route on them:
 | `PAM_AUTH_ERR` | No agent key matched `authorized_keys`, or every matched key was refused / failed verification (user denied the touch, agent rejected, etc.). |
 | `PAM_AUTHINFO_UNAVAIL` | `SSH_AUTH_SOCK` not set, agent socket unreachable, agent advertises no WebAuthn keys, or `authorized_keys` is empty. The module is fine — the info needed to authenticate just isn't present. |
 | `PAM_SERVICE_ERR` | Module misconfiguration (bad arg, unreadable / unsafe `authorized_keys`), or the agent returned a malformed protocol message. |
-| `PAM_USER_UNKNOWN` | PAM did not supply a user identity. |
 
 This lets you compose stacks like:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,15 +73,12 @@ impl PamHooks for PamSshWebauthn {
             }
             Err(e) => {
                 let code = e.pam_code();
-                // Service errors and UserUnknown get error!; everything else
-                // is info!. The distinction matters because admins triaging
-                // a syslog stream should see broken-config / malformed-
-                // protocol issues — and a calling app that failed to set
-                // PAM_USER before pam_authenticate (UserUnknown) is the same
-                // class of "module was called wrong" — separately from the
-                // expected "user denied the touch" / "no agent forwarded"
-                // events.
-                if matches!(e, AuthError::Service(_) | AuthError::UserUnknown) {
+                // Service errors get error!; everything else is info!. The
+                // distinction matters because admins triaging a syslog stream
+                // should see broken-config / malformed-protocol issues
+                // separately from the expected "user denied the touch" /
+                // "no agent forwarded" events.
+                if matches!(e, AuthError::Service(_)) {
                     error!("pam_ssh_agent_webauthn: {e}");
                 } else {
                     info!("pam_ssh_agent_webauthn: {e}");
@@ -126,8 +123,6 @@ enum AuthError {
     /// signature didn't verify, user denied the touch prompt).
     /// Maps to `PAM_AUTH_ERR`.
     AuthFail(String),
-    /// PAM did not supply the user identity. Maps to `PAM_USER_UNKNOWN`.
-    UserUnknown,
 }
 
 impl AuthError {
@@ -136,7 +131,6 @@ impl AuthError {
             Self::Service(_) => PamResultCode::PAM_SERVICE_ERR,
             Self::InfoUnavailable(_) => PamResultCode::PAM_AUTHINFO_UNAVAIL,
             Self::AuthFail(_) => PamResultCode::PAM_AUTH_ERR,
-            Self::UserUnknown => PamResultCode::PAM_USER_UNKNOWN,
         }
     }
 }
@@ -147,7 +141,6 @@ impl std::fmt::Display for AuthError {
             Self::Service(msg) => write!(f, "service error: {msg}"),
             Self::InfoUnavailable(msg) => write!(f, "auth info unavailable: {msg}"),
             Self::AuthFail(msg) => write!(f, "authentication failed: {msg}"),
-            Self::UserUnknown => write!(f, "PAM did not supply user identity"),
         }
     }
 }
@@ -255,9 +248,19 @@ enum TryAuthOutcome {
 }
 
 fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthError> {
+    // pam-bindings 0.1.1 mishandles the `const char **user` out-parameter of
+    // pam_get_user(3): the FFI binding takes `&*mut c_char` against an
+    // immutably bound pointer, and in release builds the optimizer is free
+    // to drop the C-side write, leaving the wrapper to return `Err(...)`
+    // even when pam_get_user itself returned PAM_SUCCESS.
+    // See anowell/pam-rs#16 (and the corresponding rustsec advisory).
+    // The username is purely informational here — it's logged but never used
+    // in any auth decision (this module verifies a WebAuthn signature
+    // against authorized_keys, not POSIX user identity) — so we tolerate
+    // the failure rather than letting a dependency bug fail authentication.
     let user = handle
         .get_user(None)
-        .map_err(|_| AuthError::UserUnknown)?;
+        .unwrap_or_else(|_| "<unknown>".to_string());
     info!("pam_ssh_agent_webauthn: authenticating user '{user}'");
 
     // Read authorized_keys under the OpenSSH-style safety ladder:
@@ -652,10 +655,6 @@ mod tests {
         assert_eq!(
             AuthError::AuthFail("x".into()).pam_code(),
             PamResultCode::PAM_AUTH_ERR
-        );
-        assert_eq!(
-            AuthError::UserUnknown.pam_code(),
-            PamResultCode::PAM_USER_UNKNOWN
         );
     }
 


### PR DESCRIPTION
## Summary

\`pam-bindings 0.1.1\`'s \`PamHandle::get_user\` wrapper is broken in release builds (anowell/pam-rs#16): the FFI binding for the \`const char **user\` out-parameter takes \`&*mut c_char\` against an immutably bound pointer, and the optimizer drops the C-side write, so \`pam_get_user\` returns \`PAM_SUCCESS\` but the wrapper hands back \`Err(...)\`. This caused \`PAM did not supply user identity\` for every auth attempt against an installed \`.so\` (which is built with \`cargo build --release\`).

This module never used the username for any auth decision — we verify a WebAuthn signature against \`/etc/security/authorized_keys\`, not against POSIX user identity — so swallowing the failure is correct. We restore the original (pre-#8) lenient behavior with a comment explaining why, and remove the now-unused \`AuthError::UserUnknown\` variant + its \`PAM_USER_UNKNOWN\` row from the README.

Tracking issue (when to drop the workaround): #14

## Key change

\`\`\`rust
// before
let user = handle.get_user(None).map_err(|_| AuthError::UserUnknown)?;

// after
let user = handle.get_user(None).unwrap_or_else(|_| \"<unknown>\".to_string());
\`\`\`

## Test plan

- [ ] \`cargo test --release\` passes (it does locally)
- [ ] On the affected Ubuntu host, install the new \`.so\`, run \`sudo whoami\`, observe authentication completes via WebAuthn instead of falling through to \`pam_unix\`
- [ ] Auth log shows \`authenticating user '<unknown>'\` (workaround active) or \`authenticating user 'openclaw'\` (if a future toolchain happens to preserve the FFI write) — either is fine

## Out of scope

- The pre-existing \`clippy::needless_lifetimes\` failure in \`examples/list_keys.rs\` (clippy 1.94 lint regression) is **not** addressed here — separate fix.