### PR TITLE
feat: support enforcing User Verification (verify-required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Two independent knobs control UV enforcement, both off by default:
   ```
   verify-required webauthn-sk-ecdsa-sha2-nistp256@openssh.com AAAA... user@host
   ```
-  The option may also appear inside a comma-separated options list (e.g. `cert-authority,verify-required …`), matching OpenSSH's `authorized_keys(5)` grammar.
+  Multiple options combine into a single comma-separated token before the algorithm, per OpenSSH's `authorized_keys(5)` grammar (e.g. `cert-authority,verify-required webauthn-sk-…`). Quoted values are honored (`from="a,b",verify-required …` — the comma inside `"…"` is part of the value, not an option separator). Only `verify-required` is acted on; other options (`cert-authority`, `command="…"`, `from="…"`, etc.) are tolerated but have no effect on this module.
 
 UV is enforced if **either** says so — whichever rule is stricter wins. With both off (the default), the UV bit is ignored, preserving compatibility with authenticators that do not support PIN/biometric prompts. When UV is required but the assertion lacks the bit, authentication fails with `PAM_AUTH_ERR`.
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,26 @@ This bounds the number of user-presence prompts a misbehaving or hostile ssh-age
 auth sufficient pam_ssh_agent_webauthn.so strict_modes=no
 ```
 
+### User Verification (UV) enforcement
+
+WebAuthn assertions carry both a UP bit (User Presence — touch) and a UV bit (User Verification — PIN or biometric). UP is always required by this module; UV is opt-in because not every authenticator supports it.
+
+Two independent knobs control UV enforcement, both off by default:
+
+- **Module-wide**, applies to every key:
+  ```
+  auth sufficient pam_ssh_agent_webauthn.so verify_required=yes
+  ```
+- **Per-key**, as an option in `/etc/security/authorized_keys`:
+  ```
+  verify-required webauthn-sk-ecdsa-sha2-nistp256@openssh.com AAAA... user@host
+  ```
+  The option may also appear inside a comma-separated options list (e.g. `cert-authority,verify-required …`), matching OpenSSH's `authorized_keys(5)` grammar.
+
+UV is enforced if **either** says so — whichever rule is stricter wins. With both off (the default), the UV bit is ignored, preserving compatibility with authenticators that do not support PIN/biometric prompts. When UV is required but the assertion lacks the bit, authentication fails with `PAM_AUTH_ERR`.
+
+These are the same two surfaces OpenSSH exposes for SK keys (`PubkeyAuthOptions verify-required` in `sshd_config` and the `verify-required` `authorized_keys` option) — except the global form lives on the PAM module line, since this module never sees `sshd_config`.
+
 ### PAM return codes
 
 The module distinguishes failure modes so PAM stacks can route on them:
@@ -234,7 +254,7 @@ The following checks are performed, matching OpenSSH's `webauthn_check_prepare_h
 ### Limitations
 
 - **No counter/replay protection**: The WebAuthn counter is integrity-protected (included in signed_data) but not checked for monotonic increase. Counter validation requires persistent state (tracking the last-seen counter per key), which is not appropriate for a stateless PAM module. This means a captured signature cannot be replayed (the challenge is fresh each time), but a cloned authenticator with a reset counter would not be detected.
-- **No User Verification (UV) enforcement**: The UV flag is not required, as some authenticators may not support it. UP (User Presence) is always required.
+- **User Verification (UV) is opt-in**: The default is permissive (UP only) so that authenticators without PIN/biometric support keep working. Operators who want to enforce UV have two independent knobs — a module-wide arg and a per-key option — see [User Verification (UV) enforcement](#user-verification-uv-enforcement) below. UP (User Presence) is always required.
 
 ## Logging
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -80,32 +80,45 @@ pub fn parse_authorized_keys_str(content: &str) -> Vec<WebAuthnPublicKey> {
 ///
 /// Format: `[options] webauthn-sk-ecdsa-sha2-nistp256@openssh.com <base64> [comment]`
 ///
-/// Options handling: only `verify-required` is recognised. Any other option
-/// tokens (`cert-authority`, `command="..."`, `from="..."`, etc.) are
-/// silently tolerated as today — they have no effect on this module. Options
-/// may appear as separate whitespace-delimited tokens or as a single
-/// comma-separated token, matching OpenSSH's authorized_keys(5) grammar.
+/// Tokenisation matches OpenSSH's `authorized_keys(5)` grammar (see
+/// `sshkey_advance_past_options` in OpenSSH `authfile.c`): the options
+/// block, if present, ends at the first **unquoted** whitespace, with `\"`
+/// recognised as the only escape inside `"..."`. This matters because
+/// option values can carry embedded spaces or commas (`command="ls -la"`,
+/// `from="a,b"`) which a naïve whitespace split would mishandle.
+///
+/// Of the recognised flag options, only `verify-required` is acted on; the
+/// rest (`cert-authority`, `command="..."`, `from="..."`, `principals=`,
+/// etc.) are silently tolerated as today. Lines whose options block is
+/// malformed (e.g. unterminated quote, multiple whitespace-separated tokens
+/// before the algorithm — not legal per OpenSSH) are skipped.
 fn parse_authorized_key_line(line: &str) -> Option<WebAuthnPublicKey> {
-    let parts: Vec<&str> = line.split_whitespace().collect();
+    let line = line.trim_start();
 
-    // Find the algorithm field
-    let algo_idx = parts.iter().position(|&p| p == WEBAUTHN_SK_ALGO)?;
-    let b64_idx = algo_idx + 1;
-    if b64_idx >= parts.len() {
-        log::debug!("No base64 data after algorithm in line");
+    // Either the line begins with the algorithm (no options) or with an
+    // options block followed by whitespace and then the algorithm.
+    let (options, after_options) = if line_starts_with_algo(line) {
+        ("", line)
+    } else {
+        let opts_end = advance_past_options(line)?;
+        (&line[..opts_end], line[opts_end..].trim_start())
+    };
+
+    let after_algo = after_options.strip_prefix(WEBAUTHN_SK_ALGO)?;
+    // The algorithm token must be terminated by whitespace (or end of
+    // line); otherwise we've matched a prefix of some other longer token.
+    if !matches!(
+        after_algo.as_bytes().first().copied(),
+        None | Some(b' ') | Some(b'\t')
+    ) {
         return None;
     }
 
-    // Scan the options field (everything before the algorithm token) for
-    // `verify-required`. OpenSSH option names are case-insensitive, and the
-    // canonical form packs them comma-separated into a single token, but
-    // some operators write them whitespace-separated — handle both.
-    let verify_required = parts[..algo_idx]
-        .iter()
-        .flat_map(|tok| tok.split(','))
-        .any(|opt| opt.trim().eq_ignore_ascii_case("verify-required"));
+    let mut rest = after_algo.split_whitespace();
+    let b64 = rest.next()?;
+    let comment = rest.collect::<Vec<_>>().join(" ");
 
-    let key_blob = match BASE64_STANDARD.decode(parts[b64_idx]) {
+    let key_blob = match BASE64_STANDARD.decode(b64) {
         Ok(blob) => blob,
         Err(e) => {
             log::debug!("Failed to decode base64 key: {e}");
@@ -113,11 +126,7 @@ fn parse_authorized_key_line(line: &str) -> Option<WebAuthnPublicKey> {
         }
     };
 
-    let comment = if b64_idx + 1 < parts.len() {
-        parts[b64_idx + 1..].join(" ")
-    } else {
-        String::new()
-    };
+    let verify_required = options_have_verify_required(options);
 
     match parse_webauthn_key_blob(&key_blob) {
         Some((ec_point, application)) => Some(WebAuthnPublicKey {
@@ -132,6 +141,90 @@ fn parse_authorized_key_line(line: &str) -> Option<WebAuthnPublicKey> {
             None
         }
     }
+}
+
+/// True iff `line` begins with the WebAuthn SK algorithm followed by
+/// whitespace or end-of-string. Lets the parser skip the options block
+/// entirely on lines that have no options, without mistaking the algorithm
+/// name for a prefix of some longer string.
+fn line_starts_with_algo(line: &str) -> bool {
+    line.strip_prefix(WEBAUTHN_SK_ALGO).is_some_and(|tail| {
+        matches!(
+            tail.as_bytes().first().copied(),
+            None | Some(b' ') | Some(b'\t')
+        )
+    })
+}
+
+/// Advance past an authorized_keys options block, mirroring OpenSSH's
+/// `sshkey_advance_past_options` (authfile.c:463): the block ends at the
+/// first **unquoted** whitespace, with `\"` as the only escape inside
+/// `"..."`. Returns the byte offset where the block ends, or `None` if
+/// quotes are unterminated.
+fn advance_past_options(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut quoted = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if !quoted && (b == b' ' || b == b'\t') {
+            return Some(i);
+        }
+        if b == b'\\' && bytes.get(i + 1).copied() == Some(b'"') {
+            i += 2;
+            continue;
+        }
+        if b == b'"' {
+            quoted = !quoted;
+        }
+        i += 1;
+    }
+    if quoted {
+        None
+    } else {
+        Some(i)
+    }
+}
+
+/// Returns true iff the comma-separated authorized_keys options block
+/// `opts` contains a `verify-required` flag option, with quote awareness
+/// per OpenSSH's `opt_dequote` (misc.c:2696): inside `"..."`, commas are
+/// literal and `\"` is the only escape. Option names are matched
+/// case-insensitively (`strncasecmp` in OpenSSH).
+///
+/// Quote awareness matters because an option like `from="a,verify-required,b"`
+/// embeds commas in its quoted value — a naïve `split(',')` would falsely
+/// pull `verify-required` out of that value.
+fn options_have_verify_required(opts: &str) -> bool {
+    let bytes = opts.as_bytes();
+    let mut start = 0;
+    let mut i = 0;
+    let mut quoted = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if quoted {
+            if b == b'\\' && bytes.get(i + 1).copied() == Some(b'"') {
+                i += 2;
+                continue;
+            }
+            if b == b'"' {
+                quoted = false;
+            }
+            i += 1;
+        } else if b == b'"' {
+            quoted = true;
+            i += 1;
+        } else if b == b',' {
+            if opts[start..i].eq_ignore_ascii_case("verify-required") {
+                return true;
+            }
+            i += 1;
+            start = i;
+        } else {
+            i += 1;
+        }
+    }
+    opts[start..].eq_ignore_ascii_case("verify-required")
 }
 
 /// Parse the wire format of a webauthn-sk-ecdsa key blob.
@@ -266,6 +359,77 @@ mod tests {
 
         let key = parse_authorized_key_line(&line).unwrap();
         assert!(!key.verify_required);
+    }
+
+    #[test]
+    fn test_parse_authorized_key_line_quoted_comma_is_not_a_separator() {
+        // OpenSSH's opt_dequote treats commas inside "..." as literal.
+        // A `from=` value carrying the literal substring "verify-required"
+        // between commas must NOT trigger UV enforcement — that comma is
+        // part of the value, not an option separator.
+        let blob = make_test_key_blob("localhost");
+        let b64 = BASE64_STANDARD.encode(&blob);
+        let line = format!(r#"from="a,verify-required,b" {WEBAUTHN_SK_ALGO} {b64}"#);
+
+        let key = parse_authorized_key_line(&line).unwrap();
+        assert!(
+            !key.verify_required,
+            "comma inside quoted from= value must not be treated as an option separator"
+        );
+    }
+
+    #[test]
+    fn test_parse_authorized_key_line_quoted_space_in_option_value() {
+        // command="ls -la" carries a space inside the quoted value. The
+        // options block ends at the first UNQUOTED whitespace, so the
+        // algorithm token still parses correctly.
+        let blob = make_test_key_blob("localhost");
+        let b64 = BASE64_STANDARD.encode(&blob);
+        let line = format!(r#"command="ls -la",verify-required {WEBAUTHN_SK_ALGO} {b64} c"#);
+
+        let key = parse_authorized_key_line(&line).unwrap();
+        assert!(key.verify_required);
+        assert_eq!(key.comment, "c");
+    }
+
+    #[test]
+    fn test_parse_authorized_key_line_rejects_whitespace_separated_options() {
+        // OpenSSH's authorized_keys grammar requires options to be a single
+        // comma-separated token; whitespace ENDS the options block. So
+        // `verify-required cert-authority webauthn-sk-...` is malformed —
+        // OpenSSH would treat `verify-required` as the entire options
+        // block and then try to parse `cert-authority` as the algorithm,
+        // failing. Match that — skip the line cleanly instead of silently
+        // honouring a non-canonical form.
+        let blob = make_test_key_blob("localhost");
+        let b64 = BASE64_STANDARD.encode(&blob);
+        let line = format!("verify-required cert-authority {WEBAUTHN_SK_ALGO} {b64}");
+
+        assert!(parse_authorized_key_line(&line).is_none());
+    }
+
+    #[test]
+    fn test_parse_authorized_key_line_rejects_unterminated_quote() {
+        // A line with an unterminated quote in its options block is
+        // malformed; advance_past_options returns None and we skip the line.
+        let blob = make_test_key_blob("localhost");
+        let b64 = BASE64_STANDARD.encode(&blob);
+        let line = format!(r#"from="oops {WEBAUTHN_SK_ALGO} {b64}"#);
+
+        assert!(parse_authorized_key_line(&line).is_none());
+    }
+
+    #[test]
+    fn test_parse_authorized_key_line_escaped_quote_inside_value() {
+        // \" inside "..." is the only recognised escape per opt_dequote;
+        // the embedded quote must not toggle quoted state. Comma-after-
+        // closing-quote splits the option list normally.
+        let blob = make_test_key_blob("localhost");
+        let b64 = BASE64_STANDARD.encode(&blob);
+        let line = format!(r#"command="echo \"hi\"",verify-required {WEBAUTHN_SK_ALGO} {b64}"#);
+
+        let key = parse_authorized_key_line(&line).unwrap();
+        assert!(key.verify_required);
     }
 
     #[test]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -49,6 +49,11 @@ pub struct WebAuthnPublicKey {
     pub application: String,
     /// Optional comment from the authorized_keys line.
     pub comment: String,
+    /// Per-key `verify-required` option from the authorized_keys options
+    /// field. When true, the WebAuthn assertion for this key must carry the
+    /// UV (User Verification) flag — independent of the module-wide setting,
+    /// which is OR-ed in at the call site.
+    pub verify_required: bool,
 }
 
 /// Parse all WebAuthn SK public keys from an authorized_keys file.
@@ -74,6 +79,12 @@ pub fn parse_authorized_keys_str(content: &str) -> Vec<WebAuthnPublicKey> {
 /// Parse a single authorized_keys line for a webauthn-sk-ecdsa key.
 ///
 /// Format: `[options] webauthn-sk-ecdsa-sha2-nistp256@openssh.com <base64> [comment]`
+///
+/// Options handling: only `verify-required` is recognised. Any other option
+/// tokens (`cert-authority`, `command="..."`, `from="..."`, etc.) are
+/// silently tolerated as today — they have no effect on this module. Options
+/// may appear as separate whitespace-delimited tokens or as a single
+/// comma-separated token, matching OpenSSH's authorized_keys(5) grammar.
 fn parse_authorized_key_line(line: &str) -> Option<WebAuthnPublicKey> {
     let parts: Vec<&str> = line.split_whitespace().collect();
 
@@ -84,6 +95,15 @@ fn parse_authorized_key_line(line: &str) -> Option<WebAuthnPublicKey> {
         log::debug!("No base64 data after algorithm in line");
         return None;
     }
+
+    // Scan the options field (everything before the algorithm token) for
+    // `verify-required`. OpenSSH option names are case-insensitive, and the
+    // canonical form packs them comma-separated into a single token, but
+    // some operators write them whitespace-separated — handle both.
+    let verify_required = parts[..algo_idx]
+        .iter()
+        .flat_map(|tok| tok.split(','))
+        .any(|opt| opt.trim().eq_ignore_ascii_case("verify-required"));
 
     let key_blob = match BASE64_STANDARD.decode(parts[b64_idx]) {
         Ok(blob) => blob,
@@ -105,6 +125,7 @@ fn parse_authorized_key_line(line: &str) -> Option<WebAuthnPublicKey> {
             ec_point,
             application,
             comment,
+            verify_required,
         }),
         None => {
             log::debug!("Failed to parse key blob");
@@ -197,6 +218,54 @@ mod tests {
         assert_eq!(key.application, "localhost");
         assert_eq!(key.comment, "my-key-comment");
         assert_eq!(key.ec_point.len(), 65);
+        // Default: no per-key verify-required option.
+        assert!(!key.verify_required);
+    }
+
+    #[test]
+    fn test_parse_authorized_key_line_verify_required_token() {
+        let blob = make_test_key_blob("localhost");
+        let b64 = BASE64_STANDARD.encode(&blob);
+        let line = format!("verify-required {WEBAUTHN_SK_ALGO} {b64} my-key");
+
+        let key = parse_authorized_key_line(&line).unwrap();
+        assert!(key.verify_required);
+        assert_eq!(key.comment, "my-key");
+    }
+
+    #[test]
+    fn test_parse_authorized_key_line_verify_required_in_comma_options() {
+        // OpenSSH's canonical form packs options into a single comma-separated
+        // token. Other options sit alongside `verify-required` and must not
+        // mask it.
+        let blob = make_test_key_blob("localhost");
+        let b64 = BASE64_STANDARD.encode(&blob);
+        let line = format!("cert-authority,verify-required {WEBAUTHN_SK_ALGO} {b64}");
+
+        let key = parse_authorized_key_line(&line).unwrap();
+        assert!(key.verify_required);
+    }
+
+    #[test]
+    fn test_parse_authorized_key_line_verify_required_case_insensitive() {
+        // OpenSSH option names are case-insensitive — match that.
+        let blob = make_test_key_blob("localhost");
+        let b64 = BASE64_STANDARD.encode(&blob);
+        let line = format!("Verify-Required {WEBAUTHN_SK_ALGO} {b64}");
+
+        let key = parse_authorized_key_line(&line).unwrap();
+        assert!(key.verify_required);
+    }
+
+    #[test]
+    fn test_parse_authorized_key_line_other_options_do_not_set_uv() {
+        // Unrelated options must not flip the flag.
+        let blob = make_test_key_blob("localhost");
+        let b64 = BASE64_STANDARD.encode(&blob);
+        let line = format!("cert-authority {WEBAUTHN_SK_ALGO} {b64}");
+
+        let key = parse_authorized_key_line(&line).unwrap();
+        assert!(!key.verify_required);
     }
 
     #[test]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -81,11 +81,12 @@ pub fn parse_authorized_keys_str(content: &str) -> Vec<WebAuthnPublicKey> {
 /// Format: `[options] webauthn-sk-ecdsa-sha2-nistp256@openssh.com <base64> [comment]`
 ///
 /// Tokenisation matches OpenSSH's `authorized_keys(5)` grammar (see
-/// `sshkey_advance_past_options` in OpenSSH `authfile.c`): the options
-/// block, if present, ends at the first **unquoted** whitespace, with `\"`
-/// recognised as the only escape inside `"..."`. This matters because
-/// option values can carry embedded spaces or commas (`command="ls -la"`,
-/// `from="a,b"`) which a naïve whitespace split would mishandle.
+/// `sshkey_advance_past_options` in OpenSSH's authfile module): the
+/// options block, if present, ends at the first **unquoted** whitespace,
+/// with `\"` recognised as the only escape inside `"..."`. This matters
+/// because option values can carry embedded spaces or commas
+/// (`command="ls -la"`, `from="a,b"`) which a naïve whitespace split
+/// would mishandle.
 ///
 /// Of the recognised flag options, only `verify-required` is acted on; the
 /// rest (`cert-authority`, `command="..."`, `from="..."`, `principals=`,
@@ -157,10 +158,9 @@ fn line_starts_with_algo(line: &str) -> bool {
 }
 
 /// Advance past an authorized_keys options block, mirroring OpenSSH's
-/// `sshkey_advance_past_options` (authfile.c:463): the block ends at the
-/// first **unquoted** whitespace, with `\"` as the only escape inside
-/// `"..."`. Returns the byte offset where the block ends, or `None` if
-/// quotes are unterminated.
+/// `sshkey_advance_past_options`: the block ends at the first **unquoted**
+/// whitespace, with `\"` as the only escape inside `"..."`. Returns the
+/// byte offset where the block ends, or `None` if quotes are unterminated.
 fn advance_past_options(s: &str) -> Option<usize> {
     let bytes = s.as_bytes();
     let mut i = 0;
@@ -188,13 +188,24 @@ fn advance_past_options(s: &str) -> Option<usize> {
 
 /// Returns true iff the comma-separated authorized_keys options block
 /// `opts` contains a `verify-required` flag option, with quote awareness
-/// per OpenSSH's `opt_dequote` (misc.c:2696): inside `"..."`, commas are
-/// literal and `\"` is the only escape. Option names are matched
-/// case-insensitively (`strncasecmp` in OpenSSH).
+/// per OpenSSH's `opt_dequote`: inside `"..."`, commas are literal and
+/// `\"` is the only escape. Option names are matched case-insensitively
+/// (`strncasecmp` in OpenSSH).
 ///
-/// Quote awareness matters because an option like `from="a,verify-required,b"`
-/// embeds commas in its quoted value — a naïve `split(',')` would falsely
-/// pull `verify-required` out of that value.
+/// Quote awareness matters because an option like
+/// `from="a,verify-required,b"` embeds commas in its quoted value — a
+/// naïve `split(',')` would falsely pull `verify-required` out of that
+/// value.
+///
+/// Scope: this function only looks for `verify-required`. Per the project
+/// proposal, every other option (recognised by OpenSSH or not) is
+/// tolerated — including malformed shapes like leading/double commas or
+/// unknown option names. OpenSSH's option loop tolerates empty segments
+/// at the loop level too (its rejections come from the surrounding
+/// "unknown option" / "trailing comma" checks, which are out of scope
+/// here). All ways a malformed line can mis-parse are fail-safe: the
+/// worst outcome is UV gets enforced when the operator didn't intend it,
+/// not the other way around.
 fn options_have_verify_required(opts: &str) -> bool {
     let bytes = opts.as_bytes();
     let mut start = 0;
@@ -417,6 +428,25 @@ mod tests {
         let line = format!(r#"from="oops {WEBAUTHN_SK_ALGO} {b64}"#);
 
         assert!(parse_authorized_key_line(&line).is_none());
+    }
+
+    #[test]
+    fn test_parse_authorized_key_line_tolerates_empty_segments() {
+        // Pin the scope decision documented on `options_have_verify_required`:
+        // empty segments (leading comma, double comma) are tolerated and do
+        // not change behavior. OpenSSH's option loop is similarly permissive
+        // about empty segments per se. Both inputs below contain a real
+        // `verify-required` token, so they must enable UV.
+        let blob = make_test_key_blob("localhost");
+        let b64 = BASE64_STANDARD.encode(&blob);
+
+        // leading comma
+        let leading = format!(",verify-required {WEBAUTHN_SK_ALGO} {b64}");
+        assert!(parse_authorized_key_line(&leading).unwrap().verify_required);
+
+        // double comma between known options
+        let middle = format!("cert-authority,,verify-required {WEBAUTHN_SK_ALGO} {b64}");
+        assert!(parse_authorized_key_line(&middle).unwrap().verify_required);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,10 @@
 //!   call; default `6`. Mirrors OpenSSH `MaxAuthTries`. Bounds the user-
 //!   visible touch prompts a hostile agent can force by advertising many
 //!   identities whose blobs match `authorized_keys`.
+//! * `verify_required=yes|no` — require the WebAuthn UV (User Verification)
+//!   bit on every assertion; default `no`. Per-key `verify-required` in
+//!   `authorized_keys` is honored independently — UV is enforced if either
+//!   says so.
 //!
 //! ## How it works
 //!
@@ -181,6 +185,7 @@ struct Config {
     socket_path: Option<String>,
     strict_modes: bool,
     max_attempts: usize,
+    verify_required: bool,
 }
 
 fn parse_args(args: &[&CStr]) -> Result<Config, String> {
@@ -188,6 +193,7 @@ fn parse_args(args: &[&CStr]) -> Result<Config, String> {
     let mut socket_path = None;
     let mut strict_modes = true;
     let mut max_attempts = DEFAULT_MAX_SIGN_ATTEMPTS;
+    let mut verify_required = false;
 
     for arg in args {
         let s = arg.to_str().map_err(|e| format!("Invalid arg: {e}"))?;
@@ -213,6 +219,12 @@ fn parse_args(args: &[&CStr]) -> Result<Config, String> {
                 return Err(format!("Invalid max_attempts value: {value} (must be >= 1)"));
             }
             max_attempts = n;
+        } else if let Some(value) = s.strip_prefix("verify_required=") {
+            verify_required = match value {
+                "yes" | "true" | "1" => true,
+                "no" | "false" | "0" => false,
+                other => return Err(format!("Invalid verify_required value: {other}")),
+            };
         } else {
             // Refuse unknown args rather than silently dropping them: a typo
             // like `strictmodes=no` instead of `strict_modes=no` would
@@ -226,6 +238,7 @@ fn parse_args(args: &[&CStr]) -> Result<Config, String> {
         socket_path,
         strict_modes,
         max_attempts,
+        verify_required,
     })
 }
 
@@ -336,7 +349,7 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthEr
     // Mirrors standard ssh-client behavior of trying each available identity,
     // with a cap analogous to OpenSSH's MaxAuthTries.
     let cap = config.max_attempts;
-    match iter_attempts(socket, &matched, cap)? {
+    match iter_attempts(socket, &matched, cap, config.verify_required)? {
         AttemptOutcome::Succeeded => Ok(()),
         AttemptOutcome::CapHit { tried } => {
             // A hostile agent advertising N>cap identities matching
@@ -412,6 +425,7 @@ fn iter_attempts(
     socket: &Path,
     matched: &[(&agent::AgentIdentity, &keys::WebAuthnPublicKey)],
     cap: usize,
+    module_uv_required: bool,
 ) -> Result<AttemptOutcome, AuthError> {
     let mut tried = 0;
     for (agent_id, auth_key) in matched.iter() {
@@ -423,7 +437,7 @@ fn iter_attempts(
             "Trying matched key: {} (app: {})",
             auth_key.comment, auth_key.application
         );
-        match try_authenticate(socket, auth_key, &agent_id.key_blob) {
+        match try_authenticate(socket, auth_key, &agent_id.key_blob, module_uv_required) {
             Ok(()) => return Ok(AttemptOutcome::Succeeded),
             Err(TryAuthOutcome::Refused(msg)) => {
                 warn!(
@@ -457,6 +471,7 @@ fn try_authenticate(
     socket: &Path,
     key: &keys::WebAuthnPublicKey,
     key_blob: &[u8],
+    module_uv_required: bool,
 ) -> Result<(), TryAuthOutcome> {
     // Generate random challenge
     let mut challenge = [0u8; CHALLENGE_SIZE];
@@ -474,8 +489,12 @@ fn try_authenticate(
         }
     };
 
+    // UV is enforced if either the module-wide arg or the per-key option
+    // requires it (whichever is stricter wins).
+    let uv_required = module_uv_required || key.verify_required;
+
     // Verify WebAuthn signature
-    webauthn::verify_webauthn_sk(key, &challenge, &raw_sig)
+    webauthn::verify_webauthn_sk(key, &challenge, &raw_sig, uv_required)
         .map_err(|e| TryAuthOutcome::VerifyFailed(e.to_string()))?;
 
     Ok(())
@@ -553,8 +572,10 @@ pub fn authenticate_with_max_attempts(
     // in the PAM hook context (root, syslog wired up). If this helper is
     // ever promoted out of `#[doc(hidden)]` to a supported API, switch to
     // `iter_attempts` so embedders get the same observability.
+    // Test helper: leave the module-wide UV knob off. The per-key
+    // `verify-required` flag still applies because it's stored on the key.
     for (agent_id, auth_key) in matched.iter().take(max_attempts) {
-        match try_authenticate(socket_path, auth_key, &agent_id.key_blob) {
+        match try_authenticate(socket_path, auth_key, &agent_id.key_blob, false) {
             Ok(()) => return Ok(true),
             Err(TryAuthOutcome::Transport(e)) => return Err(Box::new(e)),
             Err(TryAuthOutcome::Random(msg)) => return Err(msg.into()),
@@ -587,15 +608,46 @@ mod tests {
         assert!(cfg.socket_path.is_none());
         assert!(cfg.strict_modes);
         assert_eq!(cfg.max_attempts, DEFAULT_MAX_SIGN_ATTEMPTS);
+        // Default preserves current behavior: UV not required.
+        assert!(!cfg.verify_required);
     }
 
     #[test]
     fn parse_args_known_keys() {
-        let cfg = parse(&["file=/x", "socket=/y", "strict_modes=no", "max_attempts=3"]).unwrap();
+        let cfg = parse(&[
+            "file=/x",
+            "socket=/y",
+            "strict_modes=no",
+            "max_attempts=3",
+            "verify_required=yes",
+        ])
+        .unwrap();
         assert_eq!(cfg.key_file, "/x");
         assert_eq!(cfg.socket_path.as_deref(), Some("/y"));
         assert!(!cfg.strict_modes);
         assert_eq!(cfg.max_attempts, 3);
+        assert!(cfg.verify_required);
+    }
+
+    #[test]
+    fn parse_args_verify_required_accepts_synonyms() {
+        for (val, expected) in [
+            ("yes", true),
+            ("true", true),
+            ("1", true),
+            ("no", false),
+            ("false", false),
+            ("0", false),
+        ] {
+            let cfg = parse(&[&format!("verify_required={val}")]).unwrap();
+            assert_eq!(cfg.verify_required, expected, "value {val}");
+        }
+    }
+
+    #[test]
+    fn parse_args_rejects_invalid_verify_required_value() {
+        let err = parse(&["verify_required=maybe"]).unwrap_err();
+        assert!(err.contains("verify_required"), "got: {err}");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,7 +530,7 @@ pub fn authenticate(
     socket_path: &Path,
     key_file: &Path,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    authenticate_with_max_attempts(socket_path, key_file, DEFAULT_MAX_SIGN_ATTEMPTS)
+    authenticate_with_options(socket_path, key_file, DEFAULT_MAX_SIGN_ATTEMPTS, false)
 }
 
 /// Like [`authenticate`] but with a caller-supplied cap on how many sign
@@ -547,6 +547,24 @@ pub fn authenticate_with_max_attempts(
     socket_path: &Path,
     key_file: &Path,
     max_attempts: usize,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    authenticate_with_options(socket_path, key_file, max_attempts, false)
+}
+
+/// Like [`authenticate_with_max_attempts`] but also exposes the module-wide
+/// `verify_required` knob, so integration tests can drive the full UV
+/// pipeline (parse_args → Config.verify_required → try_authenticate →
+/// validate_flags) end-to-end. Per-key `verify-required` from
+/// `authorized_keys` is OR-combined as in the PAM hook — stricter wins.
+///
+/// `#[doc(hidden)]`: same caveat as [`authenticate`] — test helper, not
+/// part of the supported API surface.
+#[doc(hidden)]
+pub fn authenticate_with_options(
+    socket_path: &Path,
+    key_file: &Path,
+    max_attempts: usize,
+    module_uv_required: bool,
 ) -> Result<bool, Box<dyn std::error::Error>> {
     if max_attempts == 0 {
         return Err("max_attempts must be >= 1".into());
@@ -572,10 +590,8 @@ pub fn authenticate_with_max_attempts(
     // in the PAM hook context (root, syslog wired up). If this helper is
     // ever promoted out of `#[doc(hidden)]` to a supported API, switch to
     // `iter_attempts` so embedders get the same observability.
-    // Test helper: leave the module-wide UV knob off. The per-key
-    // `verify-required` flag still applies because it's stored on the key.
     for (agent_id, auth_key) in matched.iter().take(max_attempts) {
-        match try_authenticate(socket_path, auth_key, &agent_id.key_blob, false) {
+        match try_authenticate(socket_path, auth_key, &agent_id.key_blob, module_uv_required) {
             Ok(()) => return Ok(true),
             Err(TryAuthOutcome::Transport(e)) => return Err(Box::new(e)),
             Err(TryAuthOutcome::Random(msg)) => return Err(msg.into()),

--- a/src/webauthn.rs
+++ b/src/webauthn.rs
@@ -14,6 +14,7 @@ use crate::keys::WebAuthnPublicKey;
 
 // WebAuthn authenticator flags (from the spec)
 const FLAG_UP: u8 = 0x01; // User Presence
+const FLAG_UV: u8 = 0x04; // User Verification
 const FLAG_AD: u8 = 0x40; // Attested Credential Data
 const FLAG_ED: u8 = 0x80; // Extension Data
 
@@ -74,11 +75,12 @@ pub fn verify_webauthn_sk(
     key: &WebAuthnPublicKey,
     challenge: &[u8],
     raw_sig_blob: &[u8],
+    uv_required: bool,
 ) -> Result<(), VerifyError> {
     let sig = parse_webauthn_signature(raw_sig_blob)?;
 
     // Validate flags per WebAuthn/OpenSSH spec
-    validate_flags(sig.flags, &sig.extensions)?;
+    validate_flags(sig.flags, &sig.extensions, uv_required)?;
 
     // Validate origin contains no quote characters (prevents JSON injection,
     // matches OpenSSH's webauthn_check_prepare_hash validation)
@@ -155,11 +157,25 @@ impl From<io::Error> for VerifyError {
 // --- Validation ---
 
 /// Validate authenticator flags per WebAuthn spec and OpenSSH convention.
-fn validate_flags(flags: u8, extensions: &[u8]) -> Result<(), VerifyError> {
+///
+/// `uv_required` is the merged decision from the module-wide `verify_required`
+/// arg and the per-key `verify-required` option (UV is enforced if either says
+/// so). When `false`, UV is left unchecked to preserve compatibility with
+/// authenticators that do not support PIN/biometric prompts.
+fn validate_flags(flags: u8, extensions: &[u8], uv_required: bool) -> Result<(), VerifyError> {
     // User Presence (UP) must be set — required for sudo authentication
     if flags & FLAG_UP == 0 {
         return Err(VerifyError::InvalidFlags(
             "User Presence (UP) flag not set".to_string(),
+        ));
+    }
+
+    // User Verification (UV) is enforced only when the operator opts in,
+    // because not every authenticator supports it (some hardware tokens
+    // implement UP but not UV).
+    if uv_required && flags & FLAG_UV == 0 {
+        return Err(VerifyError::InvalidFlags(
+            "User Verification (UV) flag not set but verify-required is in effect".to_string(),
         ));
     }
 
@@ -556,35 +572,55 @@ mod tests {
     #[test]
     fn test_validate_flags_up_required() {
         // flags=0x00 — no UP → reject
-        let err = validate_flags(0x00, &[]).unwrap_err();
+        let err = validate_flags(0x00, &[], false).unwrap_err();
         assert!(matches!(err, VerifyError::InvalidFlags(_)));
 
         // flags=0x01 — UP set → ok
-        assert!(validate_flags(0x01, &[]).is_ok());
+        assert!(validate_flags(0x01, &[], false).is_ok());
 
         // flags=0x05 — UP + UV → ok
-        assert!(validate_flags(0x05, &[]).is_ok());
+        assert!(validate_flags(0x05, &[], false).is_ok());
     }
 
     #[test]
     fn test_validate_flags_ad_rejected() {
         // AD flag (0x40) must not be set
-        let err = validate_flags(0x41, &[]).unwrap_err(); // UP + AD
+        let err = validate_flags(0x41, &[], false).unwrap_err(); // UP + AD
         assert!(matches!(err, VerifyError::InvalidFlags(_)));
     }
 
     #[test]
     fn test_validate_flags_ed_consistency() {
         // ED set but no extensions → reject
-        let err = validate_flags(0x81, &[]).unwrap_err(); // UP + ED, empty extensions
+        let err = validate_flags(0x81, &[], false).unwrap_err(); // UP + ED, empty extensions
         assert!(matches!(err, VerifyError::InvalidFlags(_)));
 
         // ED not set but extensions present → reject
-        let err = validate_flags(0x01, &[0x01, 0x02]).unwrap_err();
+        let err = validate_flags(0x01, &[0x01, 0x02], false).unwrap_err();
         assert!(matches!(err, VerifyError::InvalidFlags(_)));
 
         // ED set with extensions → ok
-        assert!(validate_flags(0x81, &[0x01, 0x02]).is_ok());
+        assert!(validate_flags(0x81, &[0x01, 0x02], false).is_ok());
+    }
+
+    #[test]
+    fn test_validate_flags_uv_required_ok_when_set() {
+        // verify-required is in effect AND UV bit is set → accept.
+        assert!(validate_flags(FLAG_UP | FLAG_UV, &[], true).is_ok());
+    }
+
+    #[test]
+    fn test_validate_flags_uv_required_rejects_when_unset() {
+        // verify-required is in effect but UV bit is missing → InvalidFlags.
+        let err = validate_flags(FLAG_UP, &[], true).unwrap_err();
+        assert!(matches!(err, VerifyError::InvalidFlags(_)));
+    }
+
+    #[test]
+    fn test_validate_flags_uv_unset_ok_when_not_required() {
+        // Default behavior (no opt-in): UV bit unset must still pass so that
+        // authenticators without UV support keep working.
+        assert!(validate_flags(FLAG_UP, &[], false).is_ok());
     }
 
     #[test]

--- a/tests/webauthn_roundtrip.rs
+++ b/tests/webauthn_roundtrip.rs
@@ -923,3 +923,70 @@ fn test_uv_not_required_default_accepts_up_only_signature() {
     );
     assert_eq!(observed, 1);
 }
+
+#[test]
+fn test_uv_required_module_wide_rejects_up_only_signature() {
+    // End-to-end coverage for the OTHER half of the OR-combine: the
+    // module-wide `verify_required=yes` arg (which the PAM hook reads
+    // from its module argument list). The key file has NO per-key
+    // option; UV enforcement comes purely from the module-wide knob
+    // threaded through try_authenticate. This locks in the wiring from
+    // Config.verify_required → iter_attempts → try_authenticate →
+    // validate_flags so a future regression that drops the parameter
+    // would be caught at the integration level, not just the parse_args
+    // unit test.
+    let (socket_path, key_file, sign_count, stop, thread) = setup_uv_test(0x01, "");
+
+    // module_uv_required = true, no per-key option → UV demanded only by
+    // the module-wide knob.
+    let result = pam_ssh_agent_webauthn::authenticate_with_options(
+        &socket_path,
+        &key_file,
+        6,
+        true,
+    );
+    let observed = sign_count.load(Ordering::Relaxed);
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = thread.join();
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(&key_file);
+
+    assert!(
+        matches!(result, Ok(false)),
+        "module-wide verify_required=yes must reject a UP-only signature, got {result:?}"
+    );
+    assert_eq!(
+        observed, 1,
+        "agent should sign once before module-wide UV verification rejects the result"
+    );
+}
+
+#[test]
+fn test_uv_required_module_wide_accepts_uv_signature() {
+    // Positive control for module-wide UV: same module knob set, but the
+    // agent now signs with UP+UV (flags=0x05). Auth must succeed,
+    // proving the rejection in the test above is specifically the UV
+    // check and not some side effect of `authenticate_with_options`
+    // itself.
+    let (socket_path, key_file, sign_count, stop, thread) = setup_uv_test(0x05, "");
+
+    let result = pam_ssh_agent_webauthn::authenticate_with_options(
+        &socket_path,
+        &key_file,
+        6,
+        true,
+    );
+    let observed = sign_count.load(Ordering::Relaxed);
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = thread.join();
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(&key_file);
+
+    assert!(
+        matches!(result, Ok(true)),
+        "module-wide verify_required=yes must accept a UP+UV signature, got {result:?}"
+    );
+    assert_eq!(observed, 1);
+}

--- a/tests/webauthn_roundtrip.rs
+++ b/tests/webauthn_roundtrip.rs
@@ -41,9 +41,20 @@ fn make_webauthn_key_blob(signing_key: &SigningKey) -> Vec<u8> {
     blob
 }
 
-/// Build a WebAuthn-style SSH signature blob.
+/// Build a WebAuthn-style SSH signature blob with the default flags
+/// (UP + UV set). Convenience wrapper over [`build_webauthn_signature_with_flags`].
 fn build_webauthn_signature(signing_key: &SigningKey, challenge: &[u8]) -> Vec<u8> {
-    let flags: u8 = 0x05; // UP + UV
+    build_webauthn_signature_with_flags(signing_key, challenge, 0x05)
+}
+
+/// Build a WebAuthn-style SSH signature blob with explicit authenticator
+/// flags. Used by the UV-enforcement tests to produce a UP-only (no UV)
+/// signature without disturbing the other tests' assumptions.
+fn build_webauthn_signature_with_flags(
+    signing_key: &SigningKey,
+    challenge: &[u8],
+    flags: u8,
+) -> Vec<u8> {
     let counter: u32 = 42;
 
     let challenge_b64 = URL_SAFE_NO_PAD.encode(challenge);
@@ -721,4 +732,194 @@ fn test_cap_blocks_otherwise_succeeding_key() {
         observed, 1,
         "cap=1 must stop iteration after 1 sign request even though the second key would have signed; got {observed}"
     );
+}
+
+/// Mock agent that signs every request with `signing_flags` (typically
+/// 0x01 — UP only, no UV). Used to drive the UV-enforcement tests:
+/// regardless of what the policy demands, this agent never asserts UV.
+fn run_fixed_flags_agent(
+    listener: UnixListener,
+    signing_key: SigningKey,
+    key_blob: Vec<u8>,
+    signing_flags: u8,
+    sign_count: Arc<std::sync::atomic::AtomicUsize>,
+    stop: Arc<AtomicBool>,
+) {
+    listener
+        .set_nonblocking(true)
+        .expect("set_nonblocking failed");
+
+    while !stop.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                stream.set_nonblocking(false).unwrap();
+                stream
+                    .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                    .unwrap();
+
+                let mut len_buf = [0u8; 4];
+                if stream.read_exact(&mut len_buf).is_err() {
+                    continue;
+                }
+                let msg_len = u32::from_be_bytes(len_buf) as usize;
+                let mut msg = vec![0u8; msg_len];
+                if stream.read_exact(&mut msg).is_err() {
+                    continue;
+                }
+
+                match msg[0] {
+                    SSH_AGENTC_REQUEST_IDENTITIES => {
+                        let mut response = Vec::new();
+                        response.push(SSH_AGENT_IDENTITIES_ANSWER);
+                        response.extend(&1u32.to_be_bytes());
+                        write_ssh_string(&mut response, &key_blob);
+                        write_ssh_string(&mut response, b"uv-test-key");
+
+                        let len = (response.len() as u32).to_be_bytes();
+                        stream.write_all(&len).unwrap();
+                        stream.write_all(&response).unwrap();
+                        stream.flush().unwrap();
+                    }
+                    SSH_AGENTC_SIGN_REQUEST => {
+                        sign_count.fetch_add(1, Ordering::Relaxed);
+                        let mut reader: &[u8] = &msg[1..];
+                        let _key = read_ssh_bytes(&mut reader);
+                        let data = read_ssh_bytes(&mut reader).unwrap_or(b"");
+                        let sig_blob = build_webauthn_signature_with_flags(
+                            &signing_key,
+                            data,
+                            signing_flags,
+                        );
+
+                        let mut response = Vec::new();
+                        response.push(SSH_AGENT_SIGN_RESPONSE);
+                        write_ssh_string(&mut response, &sig_blob);
+
+                        let len = (response.len() as u32).to_be_bytes();
+                        stream.write_all(&len).unwrap();
+                        stream.write_all(&response).unwrap();
+                        stream.flush().unwrap();
+                    }
+                    _ => {}
+                }
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+/// Builds the scaffolding for a UV-enforcement test: an agent that signs
+/// with `signing_flags`, plus an `authorized_keys` file written from
+/// `key_options` (the leading options block, comma-separated, OpenSSH-
+/// canonical form — empty string for "no options"). Returns the paths,
+/// the sign-count, and the join handle.
+fn setup_uv_test(
+    signing_flags: u8,
+    key_options: &str,
+) -> (
+    PathBuf,
+    PathBuf,
+    Arc<std::sync::atomic::AtomicUsize>,
+    Arc<AtomicBool>,
+    std::thread::JoinHandle<()>,
+) {
+    let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let signing_key = SigningKey::from_bytes(&TEST_KEY_BYTES.into()).unwrap();
+    let key_blob = make_webauthn_key_blob(&signing_key);
+
+    let key_file = std::env::temp_dir().join(format!(
+        "pam_webauthn_test_uv_keys_{}_{id}.pub",
+        std::process::id()
+    ));
+    let b64 = BASE64_STANDARD.encode(&key_blob);
+    let line = if key_options.is_empty() {
+        format!("{WEBAUTHN_SK_ALGO} {b64} uv-test-key\n")
+    } else {
+        format!("{key_options} {WEBAUTHN_SK_ALGO} {b64} uv-test-key\n")
+    };
+    std::fs::write(&key_file, &line).unwrap();
+
+    let socket_path = std::env::temp_dir().join(format!(
+        "pam_webauthn_test_uv_agent_{}_{id}.sock",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&socket_path);
+    let listener = UnixListener::bind(&socket_path).unwrap();
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_clone = stop.clone();
+    let sign_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let sign_count_clone = sign_count.clone();
+    let key_blob_clone = key_blob.clone();
+
+    let thread = std::thread::spawn(move || {
+        run_fixed_flags_agent(
+            listener,
+            signing_key,
+            key_blob_clone,
+            signing_flags,
+            sign_count_clone,
+            stop_clone,
+        );
+    });
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    (socket_path, key_file, sign_count, stop, thread)
+}
+
+#[test]
+fn test_uv_required_per_key_rejects_up_only_signature() {
+    // End-to-end UV enforcement: the agent signs with flags=0x01 (UP only,
+    // no UV bit). The authorized_keys line carries `verify-required`, so
+    // validate_flags must reject the assertion. The module treats this as
+    // "this key didn't authenticate" and exhausts matches → Ok(false).
+    // Locks in the OR-combine wiring at the integration level: the per-key
+    // option flows from authorized_keys → WebAuthnPublicKey.verify_required
+    // → try_authenticate's merged uv_required → validate_flags.
+    let (socket_path, key_file, sign_count, stop, thread) =
+        setup_uv_test(0x01, "verify-required");
+
+    let result = pam_ssh_agent_webauthn::authenticate(&socket_path, &key_file);
+    let observed = sign_count.load(Ordering::Relaxed);
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = thread.join();
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(&key_file);
+
+    assert!(
+        matches!(result, Ok(false)),
+        "expected Ok(false) when UV-required key meets a UP-only signature, got {result:?}"
+    );
+    assert_eq!(
+        observed, 1,
+        "agent should have been asked to sign exactly once before UV verification rejected the result"
+    );
+}
+
+#[test]
+fn test_uv_not_required_default_accepts_up_only_signature() {
+    // Positive control for the test above: same signature shape (UP only,
+    // no UV), but no `verify-required` option on the key. Default policy
+    // is permissive, so this MUST succeed. Without this control, the
+    // negative test alone wouldn't prove the UV bit was the cause of
+    // failure (could be agent setup, key blob mismatch, etc.).
+    let (socket_path, key_file, sign_count, stop, thread) = setup_uv_test(0x01, "");
+
+    let result = pam_ssh_agent_webauthn::authenticate(&socket_path, &key_file);
+    let observed = sign_count.load(Ordering::Relaxed);
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = thread.join();
+    let _ = std::fs::remove_file(&socket_path);
+    let _ = std::fs::remove_file(&key_file);
+
+    assert!(
+        matches!(result, Ok(true)),
+        "default-permissive UV policy must accept a UP-only signature, got {result:?}"
+    );
+    assert_eq!(observed, 1);
 }


### PR DESCRIPTION
Closes #16.

## Summary

- New module arg `verify_required=yes|no` (default `no`) globally requires the WebAuthn UV bit on every assertion.
- New per-key `verify-required` option in `authorized_keys` (recognised both as a leading token and inside a comma-separated options list, OpenSSH-style, case-insensitive) requires UV for that key only.
- The two knobs are independent — UV is enforced if **either** says so. Default behavior is unchanged.
- `FLAG_UV = 0x04` added alongside the existing flag constants in `src/webauthn.rs`; `validate_flags` now takes `uv_required` and returns `InvalidFlags` when UV is missing under that policy.
- README "Security Considerations" / Limitations rewritten — new "User Verification (UV) enforcement" subsection documents both surfaces and notes the default is permissive.

## Test plan

- [x] `cargo test --lib` → 66 passed (includes the three acceptance-criteria UV tests in `webauthn.rs` and parser tests for the per-key option in `keys.rs`)
- [x] `cargo test --tests --examples` → 66 lib + 8 integration tests pass
- [x] `cargo clippy --lib --tests -- -D warnings` clean
- [x] Manual: `verify_required=yes` rejects an authenticator that doesn't set UV
- [x] Manual: per-key `verify-required` enforces UV only for the tagged key
- [x] Manual: default config (no arg, no option) accepts UV-unset assertions (regression guard)