### PR TITLE
chore(fmt): apply rustfmt and add cargo fmt --check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,16 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
       - name: Install PAM headers
         run: sudo apt-get install -y libpam0g-dev
+
+      - name: Format
+        run: cargo fmt --all -- --check
 
       - name: Clippy
         run: cargo clippy -- -D warnings

--- a/examples/list_keys.rs
+++ b/examples/list_keys.rs
@@ -6,8 +6,9 @@ use std::path::Path;
 fn main() {
     let socket_path = env::var("SSH_AUTH_SOCK").expect("SSH_AUTH_SOCK is not set");
 
-    let identities = pam_ssh_agent_webauthn::agent::list_webauthn_identities(Path::new(&socket_path))
-        .expect("Failed to list identities");
+    let identities =
+        pam_ssh_agent_webauthn::agent::list_webauthn_identities(Path::new(&socket_path))
+            .expect("Failed to list identities");
 
     if identities.is_empty() {
         println!("No WebAuthn SK identities found in agent.");
@@ -29,7 +30,11 @@ fn main() {
             println!("  Curve: {curve}");
         }
         if let Ok(ec_point) = read_bytes(&mut reader) {
-            println!("  EC point: {} bytes, starts with 0x{:02x}", ec_point.len(), ec_point.first().unwrap_or(&0));
+            println!(
+                "  EC point: {} bytes, starts with 0x{:02x}",
+                ec_point.len(),
+                ec_point.first().unwrap_or(&0)
+            );
             println!("  EC point hex: {}", hex(ec_point));
         }
         if let Ok(app) = read_string(&mut reader) {
@@ -43,10 +48,14 @@ fn main() {
 }
 
 fn read_bytes<'a>(buf: &mut &'a [u8]) -> Result<&'a [u8], &'static str> {
-    if buf.len() < 4 { return Err("too short"); }
+    if buf.len() < 4 {
+        return Err("too short");
+    }
     let len = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
     *buf = &buf[4..];
-    if buf.len() < len { return Err("truncated"); }
+    if buf.len() < len {
+        return Err("truncated");
+    }
     let data = &buf[..len];
     *buf = &buf[len..];
     Ok(data)
@@ -58,5 +67,8 @@ fn read_string<'a>(buf: &mut &'a [u8]) -> Result<String, &'static str> {
 }
 
 fn hex(data: &[u8]) -> String {
-    data.iter().map(|b| format!("{b:02x}")).collect::<Vec<_>>().join("")
+    data.iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join("")
 }

--- a/src/authfile.rs
+++ b/src/authfile.rs
@@ -83,25 +83,43 @@ impl Default for Opts {
 #[derive(Debug)]
 pub enum OpenError {
     NotAbsolute(PathBuf),
-    UnderUserWritableRoot { path: PathBuf, root: &'static str },
+    UnderUserWritableRoot {
+        path: PathBuf,
+        root: &'static str,
+    },
     NotRegularFile(PathBuf),
-    BadOwner { path: PathBuf, actual: u32, expected: u32 },
-    BadMode { path: PathBuf, mode: u32 },
+    BadOwner {
+        path: PathBuf,
+        actual: u32,
+        expected: u32,
+    },
+    BadMode {
+        path: PathBuf,
+        mode: u32,
+    },
     Io(io::Error),
 }
 
 impl std::fmt::Display for OpenError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NotAbsolute(p) => write!(f, "authorized_keys path is not absolute: {}", p.display()),
+            Self::NotAbsolute(p) => {
+                write!(f, "authorized_keys path is not absolute: {}", p.display())
+            }
             Self::UnderUserWritableRoot { path, root } => write!(
                 f,
                 "authorized_keys path {} is under user-writable root {root} \
                  (per-user mode is not supported)",
                 path.display()
             ),
-            Self::NotRegularFile(p) => write!(f, "authorized_keys is not a regular file: {}", p.display()),
-            Self::BadOwner { path, actual, expected } => write!(
+            Self::NotRegularFile(p) => {
+                write!(f, "authorized_keys is not a regular file: {}", p.display())
+            }
+            Self::BadOwner {
+                path,
+                actual,
+                expected,
+            } => write!(
                 f,
                 "authorized_keys {} owner uid={actual} (expected uid={expected})",
                 path.display()
@@ -278,7 +296,10 @@ mod tests {
         write_file(&f, "k\n", 0o620);
 
         let err = open_secure(&f, &test_opts()).unwrap_err();
-        assert!(matches!(err, OpenError::BadMode { mode: 0o620, .. }), "got {err:?}");
+        assert!(
+            matches!(err, OpenError::BadMode { mode: 0o620, .. }),
+            "got {err:?}"
+        );
     }
 
     #[test]
@@ -288,7 +309,10 @@ mod tests {
         write_file(&f, "k\n", 0o602);
 
         let err = open_secure(&f, &test_opts()).unwrap_err();
-        assert!(matches!(err, OpenError::BadMode { mode: 0o602, .. }), "got {err:?}");
+        assert!(
+            matches!(err, OpenError::BadMode { mode: 0o602, .. }),
+            "got {err:?}"
+        );
     }
 
     #[test]
@@ -383,9 +407,7 @@ mod tests {
         // We can't actually make a symlink chain into /tmp here without
         // owning a root-mode file in /tmp, so we steer the forbidden-roots
         // list at our scratch tree to exercise the same code path.
-        let real_prefix: &'static str = Box::leak(
-            format!("{}/", real.display()).into_boxed_str(),
-        );
+        let real_prefix: &'static str = Box::leak(format!("{}/", real.display()).into_boxed_str());
         let forbidden: &'static [&'static str] = Box::leak(Box::new([real_prefix]));
 
         let opts = Opts {
@@ -445,6 +467,9 @@ mod tests {
             ..test_opts()
         };
         let err = open_secure(&f, &opts).unwrap_err();
-        assert!(matches!(err, OpenError::BadMode { .. } | OpenError::BadOwner { .. }), "got {err:?}");
+        assert!(
+            matches!(err, OpenError::BadMode { .. } | OpenError::BadOwner { .. }),
+            "got {err:?}"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,9 @@ fn parse_args(args: &[&CStr]) -> Result<Config, String> {
                 .parse()
                 .map_err(|_| format!("Invalid max_attempts value: {value}"))?;
             if n == 0 {
-                return Err(format!("Invalid max_attempts value: {value} (must be >= 1)"));
+                return Err(format!(
+                    "Invalid max_attempts value: {value} (must be >= 1)"
+                ));
             }
             max_attempts = n;
         } else if let Some(value) = s.strip_prefix("verify_required=") {
@@ -283,8 +285,8 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthEr
         strict_modes: config.strict_modes,
         ..Default::default()
     };
-    let content = authfile::open_secure(Path::new(&config.key_file), &opts)
-        .map_err(classify_open_err)?;
+    let content =
+        authfile::open_secure(Path::new(&config.key_file), &opts).map_err(classify_open_err)?;
     let authorized_keys = keys::parse_authorized_keys_str(&content);
     if authorized_keys.is_empty() {
         // The file exists, passed all safety checks, but contains no WebAuthn
@@ -314,9 +316,8 @@ fn do_authenticate(config: &Config, handle: &mut PamHandle) -> Result<(), AuthEr
     // that file's integrity, not this socket path.
     let socket_path = match &config.socket_path {
         Some(path) => path.clone(),
-        None => std::env::var("SSH_AUTH_SOCK").map_err(|_| {
-            AuthError::InfoUnavailable("SSH_AUTH_SOCK not set".into())
-        })?,
+        None => std::env::var("SSH_AUTH_SOCK")
+            .map_err(|_| AuthError::InfoUnavailable("SSH_AUTH_SOCK not set".into()))?,
     };
     let socket = Path::new(&socket_path);
 
@@ -458,9 +459,7 @@ fn iter_attempts(
                 ));
             }
             Err(TryAuthOutcome::Random(msg)) => {
-                return Err(AuthError::Service(format!(
-                    "challenge generation: {msg}"
-                )));
+                return Err(AuthError::Service(format!("challenge generation: {msg}")));
             }
         }
     }
@@ -475,8 +474,7 @@ fn try_authenticate(
 ) -> Result<(), TryAuthOutcome> {
     // Generate random challenge
     let mut challenge = [0u8; CHALLENGE_SIZE];
-    getrandom::fill(&mut challenge)
-        .map_err(|e| TryAuthOutcome::Random(e.to_string()))?;
+    getrandom::fill(&mut challenge).map_err(|e| TryAuthOutcome::Random(e.to_string()))?;
 
     // Sign via agent
     let raw_sig = match agent::sign_raw(socket, key_blob, &challenge) {
@@ -591,7 +589,12 @@ pub fn authenticate_with_options(
     // ever promoted out of `#[doc(hidden)]` to a supported API, switch to
     // `iter_attempts` so embedders get the same observability.
     for (agent_id, auth_key) in matched.iter().take(max_attempts) {
-        match try_authenticate(socket_path, auth_key, &agent_id.key_blob, module_uv_required) {
+        match try_authenticate(
+            socket_path,
+            auth_key,
+            &agent_id.key_blob,
+            module_uv_required,
+        ) {
             Ok(()) => return Ok(true),
             Err(TryAuthOutcome::Transport(e)) => return Err(Box::new(e)),
             Err(TryAuthOutcome::Random(msg)) => return Err(msg.into()),
@@ -689,7 +692,12 @@ mod tests {
     fn parse_args_rejects_invalid_max_attempts() {
         // Zero would silently turn the module into an unconditional fail —
         // refuse it. Negatives and non-numerics are typos and equally bad.
-        for bad in ["max_attempts=0", "max_attempts=-1", "max_attempts=abc", "max_attempts="] {
+        for bad in [
+            "max_attempts=0",
+            "max_attempts=-1",
+            "max_attempts=abc",
+            "max_attempts=",
+        ] {
             let err = parse(&[bad]).expect_err(&format!("expected error for {bad}"));
             assert!(err.contains("max_attempts"), "wrong error for {bad}: {err}");
         }
@@ -698,9 +706,17 @@ mod tests {
     #[test]
     fn parse_args_rejects_unknown_arg() {
         // Common typos must be rejected, not silently dropped.
-        for bad in ["strictmodes=no", "strict-modes=no", "strict_mode=no", "garbage"] {
+        for bad in [
+            "strictmodes=no",
+            "strict-modes=no",
+            "strict_mode=no",
+            "garbage",
+        ] {
             let err = parse(&[bad]).expect_err(&format!("expected error for {bad}"));
-            assert!(err.contains("Unknown argument"), "wrong error for {bad}: {err}");
+            assert!(
+                err.contains("Unknown argument"),
+                "wrong error for {bad}: {err}"
+            );
         }
     }
 
@@ -729,10 +745,7 @@ mod tests {
     #[test]
     fn classify_io_err_routes_invalid_data_to_service() {
         let e = io::Error::new(io::ErrorKind::InvalidData, "bad");
-        assert!(matches!(
-            classify_io_err(e, "ctx"),
-            AuthError::Service(_)
-        ));
+        assert!(matches!(classify_io_err(e, "ctx"), AuthError::Service(_)));
     }
 
     #[test]

--- a/src/webauthn.rs
+++ b/src/webauthn.rs
@@ -228,12 +228,9 @@ fn validate_client_data(
         .map_err(|e| VerifyError::Parse(format!("Invalid clientDataJSON: {e}")))?;
 
     // Validate type field (WebAuthn spec step 11)
-    let type_field = parsed
-        .get("type")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| {
-            VerifyError::InvalidType("Missing 'type' field in clientDataJSON".to_string())
-        })?;
+    let type_field = parsed.get("type").and_then(|v| v.as_str()).ok_or_else(|| {
+        VerifyError::InvalidType("Missing 'type' field in clientDataJSON".to_string())
+    })?;
     if type_field != "webauthn.get" {
         return Err(VerifyError::InvalidType(format!(
             "Expected type 'webauthn.get', got '{type_field}'"
@@ -527,9 +524,8 @@ mod tests {
         let challenge = b"test-challenge-data-here!1234567";
         let encoded = URL_SAFE_NO_PAD.encode(challenge);
         let origin = "https://example.com";
-        let client_data = format!(
-            r#"{{"type":"webauthn.get","challenge":"{encoded}","origin":"{origin}"}}"#
-        );
+        let client_data =
+            format!(r#"{{"type":"webauthn.get","challenge":"{encoded}","origin":"{origin}"}}"#);
         assert!(validate_client_data(&client_data, challenge, origin).is_ok());
         assert!(validate_client_data(&client_data, b"wrong", origin).is_err());
 
@@ -544,16 +540,13 @@ mod tests {
         let origin = "https://example.com";
 
         // webauthn.create should be rejected
-        let client_data = format!(
-            r#"{{"type":"webauthn.create","challenge":"{encoded}","origin":"{origin}"}}"#
-        );
+        let client_data =
+            format!(r#"{{"type":"webauthn.create","challenge":"{encoded}","origin":"{origin}"}}"#);
         let err = validate_client_data(&client_data, challenge, origin).unwrap_err();
         assert!(matches!(err, VerifyError::InvalidType(_)));
 
         // Missing type field
-        let client_data = format!(
-            r#"{{"challenge":"{encoded}","origin":"{origin}"}}"#
-        );
+        let client_data = format!(r#"{{"challenge":"{encoded}","origin":"{origin}"}}"#);
         let err = validate_client_data(&client_data, challenge, origin).unwrap_err();
         assert!(matches!(err, VerifyError::InvalidType(_)));
     }

--- a/tests/webauthn_roundtrip.rs
+++ b/tests/webauthn_roundtrip.rs
@@ -15,9 +15,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 const TEST_KEY_BYTES: [u8; 32] = [
-    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
-    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e,
-    0x1f, 0x20,
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
 ];
 const APPLICATION: &str = "https://shellwatch.example.com";
 const WEBAUTHN_SK_ALGO: &str = "webauthn-sk-ecdsa-sha2-nistp256@openssh.com";
@@ -251,7 +250,13 @@ fn setup(corrupt_challenge: bool) -> TestSetup {
     let stop_clone = stop.clone();
 
     let thread = std::thread::spawn(move || {
-        run_mock_agent(listener, signing_key, key_blob, stop_clone, corrupt_challenge);
+        run_mock_agent(
+            listener,
+            signing_key,
+            key_blob,
+            stop_clone,
+            corrupt_challenge,
+        );
     });
 
     // Give agent time to start
@@ -284,7 +289,10 @@ fn test_webauthn_wrong_challenge() {
     // Ok(false) — auth failed, but cleanly (so PAM falls through to the next
     // module rather than reporting a service error).
     let result = pam_ssh_agent_webauthn::authenticate(&setup.socket_path, &setup.key_file);
-    assert!(matches!(result, Ok(false)), "expected Ok(false), got {result:?}");
+    assert!(
+        matches!(result, Ok(false)),
+        "expected Ok(false), got {result:?}"
+    );
 }
 
 /// Mock SSH agent that serves two WebAuthn keys; signing the first always
@@ -299,7 +307,9 @@ fn run_skip_first_agent(
     sign_count: Arc<std::sync::atomic::AtomicUsize>,
     stop: Arc<AtomicBool>,
 ) {
-    listener.set_nonblocking(true).expect("set_nonblocking failed");
+    listener
+        .set_nonblocking(true)
+        .expect("set_nonblocking failed");
 
     while !stop.load(Ordering::Relaxed) {
         match listener.accept() {
@@ -391,8 +401,14 @@ fn test_skip_failing_key_then_succeed() {
         "pam_webauthn_test_multi_keys_{}_{id}.pub",
         std::process::id()
     ));
-    let line1 = format!("{WEBAUTHN_SK_ALGO} {} deny-key\n", BASE64_STANDARD.encode(&fail_blob));
-    let line2 = format!("{WEBAUTHN_SK_ALGO} {} allow-key\n", BASE64_STANDARD.encode(&succeed_blob));
+    let line1 = format!(
+        "{WEBAUTHN_SK_ALGO} {} deny-key\n",
+        BASE64_STANDARD.encode(&fail_blob)
+    );
+    let line2 = format!(
+        "{WEBAUTHN_SK_ALGO} {} allow-key\n",
+        BASE64_STANDARD.encode(&succeed_blob)
+    );
     std::fs::write(&key_file, format!("{line1}{line2}")).unwrap();
 
     let socket_path = std::env::temp_dir().join(format!(
@@ -409,7 +425,14 @@ fn test_skip_failing_key_then_succeed() {
     let sign_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let sign_count_clone = sign_count.clone();
     let thread = std::thread::spawn(move || {
-        run_skip_first_agent(listener, fail_blob_clone, succeed_key, succeed_blob_clone, sign_count_clone, stop_clone);
+        run_skip_first_agent(
+            listener,
+            fail_blob_clone,
+            succeed_key,
+            succeed_blob_clone,
+            sign_count_clone,
+            stop_clone,
+        );
     });
     std::thread::sleep(std::time::Duration::from_millis(50));
 
@@ -420,7 +443,10 @@ fn test_skip_failing_key_then_succeed() {
     let _ = std::fs::remove_file(&socket_path);
     let _ = std::fs::remove_file(&key_file);
 
-    assert!(matches!(result, Ok(true)), "expected Ok(true), got {result:?}");
+    assert!(
+        matches!(result, Ok(true)),
+        "expected Ok(true), got {result:?}"
+    );
     assert_eq!(
         sign_count.load(Ordering::Relaxed),
         2,
@@ -446,7 +472,10 @@ fn test_transport_error_bubbles_up() {
         "pam_webauthn_test_transport_keys_{}_{id}.pub",
         std::process::id()
     ));
-    let line = format!("{WEBAUTHN_SK_ALGO} {} test-key\n", BASE64_STANDARD.encode(&key_blob));
+    let line = format!(
+        "{WEBAUTHN_SK_ALGO} {} test-key\n",
+        BASE64_STANDARD.encode(&key_blob)
+    );
     std::fs::write(&key_file, &line).unwrap();
 
     let result = pam_ssh_agent_webauthn::authenticate(&bogus_socket, &key_file);
@@ -461,9 +490,9 @@ fn test_no_matching_key() {
 
     // Write a different key to the authorized_keys file
     let other_key_bytes: [u8; 32] = [
-        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e,
-        0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c,
-        0x3d, 0x3e, 0x3f, 0x40,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+        0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e,
+        0x3f, 0x40,
     ];
     let other_signing_key = SigningKey::from_bytes(&other_key_bytes.into()).unwrap();
     let other_blob = make_webauthn_key_blob(&other_signing_key);
@@ -484,7 +513,9 @@ fn run_counting_deny_agent(
     sign_count: Arc<std::sync::atomic::AtomicUsize>,
     stop: Arc<AtomicBool>,
 ) {
-    listener.set_nonblocking(true).expect("set_nonblocking failed");
+    listener
+        .set_nonblocking(true)
+        .expect("set_nonblocking failed");
 
     while !stop.load(Ordering::Relaxed) {
         match listener.accept() {
@@ -566,8 +597,14 @@ fn test_max_attempts_caps_sign_requests() {
         "pam_webauthn_test_cap_keys_{}_{id}.pub",
         std::process::id()
     ));
-    let line_a = format!("{WEBAUTHN_SK_ALGO} {} key-a\n", BASE64_STANDARD.encode(&blob_a));
-    let line_b = format!("{WEBAUTHN_SK_ALGO} {} key-b\n", BASE64_STANDARD.encode(&blob_b));
+    let line_a = format!(
+        "{WEBAUTHN_SK_ALGO} {} key-a\n",
+        BASE64_STANDARD.encode(&blob_a)
+    );
+    let line_b = format!(
+        "{WEBAUTHN_SK_ALGO} {} key-b\n",
+        BASE64_STANDARD.encode(&blob_b)
+    );
     std::fs::write(&key_file, format!("{line_a}{line_b}")).unwrap();
 
     let socket_path = std::env::temp_dir().join(format!(
@@ -587,11 +624,7 @@ fn test_max_attempts_caps_sign_requests() {
     });
     std::thread::sleep(std::time::Duration::from_millis(50));
 
-    let result = pam_ssh_agent_webauthn::authenticate_with_max_attempts(
-        &socket_path,
-        &key_file,
-        1,
-    );
+    let result = pam_ssh_agent_webauthn::authenticate_with_max_attempts(&socket_path, &key_file, 1);
     let observed = sign_count.load(Ordering::Relaxed);
 
     stop.store(true, Ordering::Relaxed);
@@ -599,8 +632,14 @@ fn test_max_attempts_caps_sign_requests() {
     let _ = std::fs::remove_file(&socket_path);
     let _ = std::fs::remove_file(&key_file);
 
-    assert!(matches!(result, Ok(false)), "expected Ok(false), got {result:?}");
-    assert_eq!(observed, 1, "cap=1 must produce exactly 1 sign request, got {observed}");
+    assert!(
+        matches!(result, Ok(false)),
+        "expected Ok(false), got {result:?}"
+    );
+    assert_eq!(
+        observed, 1,
+        "cap=1 must produce exactly 1 sign request, got {observed}"
+    );
 }
 
 #[test]
@@ -627,8 +666,14 @@ fn test_cap_not_hit_when_match_succeeds_within_limit() {
         "pam_webauthn_test_cap_succeed_keys_{}_{id}.pub",
         std::process::id()
     ));
-    let line1 = format!("{WEBAUTHN_SK_ALGO} {} deny-key\n", BASE64_STANDARD.encode(&fail_blob));
-    let line2 = format!("{WEBAUTHN_SK_ALGO} {} allow-key\n", BASE64_STANDARD.encode(&succeed_blob));
+    let line1 = format!(
+        "{WEBAUTHN_SK_ALGO} {} deny-key\n",
+        BASE64_STANDARD.encode(&fail_blob)
+    );
+    let line2 = format!(
+        "{WEBAUTHN_SK_ALGO} {} allow-key\n",
+        BASE64_STANDARD.encode(&succeed_blob)
+    );
     std::fs::write(&key_file, format!("{line1}{line2}")).unwrap();
 
     let socket_path = std::env::temp_dir().join(format!(
@@ -645,23 +690,33 @@ fn test_cap_not_hit_when_match_succeeds_within_limit() {
     let sign_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let sign_count_clone = sign_count.clone();
     let thread = std::thread::spawn(move || {
-        run_skip_first_agent(listener, fail_blob_clone, succeed_key, succeed_blob_clone, sign_count_clone, stop_clone);
+        run_skip_first_agent(
+            listener,
+            fail_blob_clone,
+            succeed_key,
+            succeed_blob_clone,
+            sign_count_clone,
+            stop_clone,
+        );
     });
     std::thread::sleep(std::time::Duration::from_millis(50));
 
-    let result = pam_ssh_agent_webauthn::authenticate_with_max_attempts(
-        &socket_path,
-        &key_file,
-        2,
-    );
+    let result = pam_ssh_agent_webauthn::authenticate_with_max_attempts(&socket_path, &key_file, 2);
 
     stop.store(true, Ordering::Relaxed);
     let _ = thread.join();
     let _ = std::fs::remove_file(&socket_path);
     let _ = std::fs::remove_file(&key_file);
 
-    assert!(matches!(result, Ok(true)), "expected Ok(true), got {result:?}");
-    assert_eq!(sign_count.load(Ordering::Relaxed), 2, "expected 2 sign requests");
+    assert!(
+        matches!(result, Ok(true)),
+        "expected Ok(true), got {result:?}"
+    );
+    assert_eq!(
+        sign_count.load(Ordering::Relaxed),
+        2,
+        "expected 2 sign requests"
+    );
 }
 
 #[test]
@@ -693,8 +748,14 @@ fn test_cap_blocks_otherwise_succeeding_key() {
         "pam_webauthn_test_cap_blocks_keys_{}_{id}.pub",
         std::process::id()
     ));
-    let line1 = format!("{WEBAUTHN_SK_ALGO} {} deny-key\n", BASE64_STANDARD.encode(&fail_blob));
-    let line2 = format!("{WEBAUTHN_SK_ALGO} {} allow-key\n", BASE64_STANDARD.encode(&succeed_blob));
+    let line1 = format!(
+        "{WEBAUTHN_SK_ALGO} {} deny-key\n",
+        BASE64_STANDARD.encode(&fail_blob)
+    );
+    let line2 = format!(
+        "{WEBAUTHN_SK_ALGO} {} allow-key\n",
+        BASE64_STANDARD.encode(&succeed_blob)
+    );
     std::fs::write(&key_file, format!("{line1}{line2}")).unwrap();
 
     let socket_path = std::env::temp_dir().join(format!(
@@ -711,15 +772,18 @@ fn test_cap_blocks_otherwise_succeeding_key() {
     let fail_blob_clone = fail_blob.clone();
     let succeed_blob_clone = succeed_blob.clone();
     let thread = std::thread::spawn(move || {
-        run_skip_first_agent(listener, fail_blob_clone, succeed_key, succeed_blob_clone, sign_count_clone, stop_clone);
+        run_skip_first_agent(
+            listener,
+            fail_blob_clone,
+            succeed_key,
+            succeed_blob_clone,
+            sign_count_clone,
+            stop_clone,
+        );
     });
     std::thread::sleep(std::time::Duration::from_millis(50));
 
-    let result = pam_ssh_agent_webauthn::authenticate_with_max_attempts(
-        &socket_path,
-        &key_file,
-        1,
-    );
+    let result = pam_ssh_agent_webauthn::authenticate_with_max_attempts(&socket_path, &key_file, 1);
     let observed = sign_count.load(Ordering::Relaxed);
 
     stop.store(true, Ordering::Relaxed);
@@ -727,7 +791,10 @@ fn test_cap_blocks_otherwise_succeeding_key() {
     let _ = std::fs::remove_file(&socket_path);
     let _ = std::fs::remove_file(&key_file);
 
-    assert!(matches!(result, Ok(false)), "expected Ok(false), got {result:?}");
+    assert!(
+        matches!(result, Ok(false)),
+        "expected Ok(false), got {result:?}"
+    );
     assert_eq!(
         observed, 1,
         "cap=1 must stop iteration after 1 sign request even though the second key would have signed; got {observed}"
@@ -785,11 +852,8 @@ fn run_fixed_flags_agent(
                         let mut reader: &[u8] = &msg[1..];
                         let _key = read_ssh_bytes(&mut reader);
                         let data = read_ssh_bytes(&mut reader).unwrap_or(b"");
-                        let sig_blob = build_webauthn_signature_with_flags(
-                            &signing_key,
-                            data,
-                            signing_flags,
-                        );
+                        let sig_blob =
+                            build_webauthn_signature_with_flags(&signing_key, data, signing_flags);
 
                         let mut response = Vec::new();
                         response.push(SSH_AGENT_SIGN_RESPONSE);
@@ -879,8 +943,7 @@ fn test_uv_required_per_key_rejects_up_only_signature() {
     // Locks in the OR-combine wiring at the integration level: the per-key
     // option flows from authorized_keys → WebAuthnPublicKey.verify_required
     // → try_authenticate's merged uv_required → validate_flags.
-    let (socket_path, key_file, sign_count, stop, thread) =
-        setup_uv_test(0x01, "verify-required");
+    let (socket_path, key_file, sign_count, stop, thread) = setup_uv_test(0x01, "verify-required");
 
     let result = pam_ssh_agent_webauthn::authenticate(&socket_path, &key_file);
     let observed = sign_count.load(Ordering::Relaxed);
@@ -939,12 +1002,8 @@ fn test_uv_required_module_wide_rejects_up_only_signature() {
 
     // module_uv_required = true, no per-key option → UV demanded only by
     // the module-wide knob.
-    let result = pam_ssh_agent_webauthn::authenticate_with_options(
-        &socket_path,
-        &key_file,
-        6,
-        true,
-    );
+    let result =
+        pam_ssh_agent_webauthn::authenticate_with_options(&socket_path, &key_file, 6, true);
     let observed = sign_count.load(Ordering::Relaxed);
 
     stop.store(true, Ordering::Relaxed);
@@ -971,12 +1030,8 @@ fn test_uv_required_module_wide_accepts_uv_signature() {
     // itself.
     let (socket_path, key_file, sign_count, stop, thread) = setup_uv_test(0x05, "");
 
-    let result = pam_ssh_agent_webauthn::authenticate_with_options(
-        &socket_path,
-        &key_file,
-        6,
-        true,
-    );
+    let result =
+        pam_ssh_agent_webauthn::authenticate_with_options(&socket_path, &key_file, 6, true);
     let observed = sign_count.load(Ordering::Relaxed);
 
     stop.store(true, Ordering::Relaxed);


### PR DESCRIPTION
## Summary
- Run `cargo fmt` over the tree to clear drift introduced by rustfmt 1.8.0-stable's tighter chain/macro/match-arm width heuristics. No source-meaning changes — purely whitespace/wrapping.
- Add a `Format` step to `ci.yml` (`cargo fmt --all -- --check`) and pull `rustfmt` into the toolchain components, so future drift fails CI instead of accumulating silently.

## Why now
Local `rustfmt 1.8.0-stable` reformats files that were fine on older stables. CI uses `dtolnay/rust-toolchain@stable` (unpinned) and never ran `cargo fmt --check`, so the drift wasn't caught.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean (matches CI command)
- [x] `cargo test` — 72 unit + 12 integration tests pass